### PR TITLE
Create Guest Users on Plan if no User is Specified

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -38,12 +38,20 @@ module Api
     # Actions to take after successfully authenticated a user token.
     # This is run automatically on successful token authentication
     def after_successful_token_authentication
-      @traveler = current_api_user  # Sets the @traveler variable to the current api user
+      @traveler = current_api_user # Sets the @traveler variable to the current api user
     end
 
     # Finds the User associated with auth headers.
     def current_api_user
       auth_headers ? User.find_by(auth_headers) : nil
+    end
+
+    # Ensure that a user object is created and loaded as @traveler
+    def current_or_guest_user
+      if @traveler.nil?
+        @traveler = create_guest_user
+      end
+      @traveler
     end
 
     # Returns a hash of authentication headers, or false if not present
@@ -107,6 +115,13 @@ module Api
       }
     end
     
+
+    def create_guest_user
+      u = User.create(first_name: "Guest", last_name: "User", email: "guest_#{Time.now.to_i}#{rand(100)}@example.com")
+      u.save!(:validate => false)
+      session[:guest_user_id] = u.id
+      u
+    end
 
   end
 end

--- a/app/controllers/api/v1/trips_controller.rb
+++ b/app/controllers/api/v1/trips_controller.rb
@@ -20,6 +20,7 @@ module Api
 
       # POST trips/, POST itineraries/plan
       def create
+
         # Create an array of strong trip parameters based on itinerary_request sent
         api_v1_params = params[:itinerary_request]
         api_v2_params = params[:trips]

--- a/app/controllers/api/v1/trips_controller.rb
+++ b/app/controllers/api/v1/trips_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class TripsController < ApiController
       before_action :require_authentication, only: [:past_trips, :future_trips, :select, :cancel, :index]
+      before_action :current_or_guest_user, only: [:create] #If @traveler is not set, then create a guest user account
 
       # GET trips/past_trips
       # Returns past trips associated with logged in user, limit by max_results param

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,11 @@ class User < ApplicationRecord
     self.has_role? :admin
   end
 
+  # Check to see if the user is a guest traveler
+  def guest?
+    self.email.include? "@example.com"
+  end
+
   ### Update Profle from API Call ###
 
   def update_profile params

--- a/app/serializers/api/v1/trip_serializer.rb
+++ b/app/serializers/api/v1/trip_serializer.rb
@@ -4,7 +4,7 @@ module Api
     class TripSerializer < ActiveModel::Serializer
 
       attributes  :id, :trip_id, :user_id, :arrive_by, :trip_time,
-                  :accommodations, :characteristics, :purposes
+                  :accommodations, :characteristics, :purposes, :new_guest_user
       has_many :itineraries
       belongs_to :origin
       belongs_to :destination
@@ -26,6 +26,15 @@ module Api
       # Get a list of relevant purposes
       def purposes
         object.relevant_purposes ? object.relevant_purposes.collect{ |tp| {name: tp.name, code: tp.code}} : []
+      end
+
+      # If this trip is a new guest user, return the email and token
+      def new_guest_user
+        if object.user.guest? and object.user.trips.count == 1
+          {email: object.user.email, authentication_token: object.user.authentication_token}
+        else
+          nil
+        end
       end
 
     end

--- a/spec/controllers/api/v1/trips_controller_spec.rb
+++ b/spec/controllers/api/v1/trips_controller_spec.rb
@@ -69,12 +69,24 @@ RSpec.describe Api::V1::TripsController, type: :controller do
   # end
 
   it 'allows creation of trips by guest users' do
+    user_count = User.count
     post :create, params: plan_call_params
     response_body = JSON.parse(response.body)
 
     expect(response).to be_success
-    expect(response_body["user_id"]).to be_nil
+    expect(User.count).to eq(user_count+1)
+    expect(response_body["new_guest_user"]).to be
   end
+
+  it 'does not create a new guest user when a user is passed' do
+    user_count = User.count
+    request.headers.merge!(request_headers) # Send user email and token headers
+    post :create, params: plan_paratransit_call_without_purpose
+    response_body = JSON.parse(response.body)
+    expect(response).to be_success
+    expect(User.count).to eq(user_count)
+    expect(response_body["new_guest_user"]).to be_nil
+  end  
 
   it 'sends back itineraries' do
     # Stub out trip creation because itinerary planning happens in TripPlanner

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -23,6 +23,10 @@ FactoryGirl.define do
       preferred_trip_types ['transit', 'unicycle']
     end
 
+    factory :guest do 
+      email "guest_xxx@example.com"
+    end
+
     trait :needs_accommodation do
       after(:create) do |u|
         u.accommodations << create(:wheelchair)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe User, type: :model do
 
   let!(:english_traveler) { FactoryGirl.create(:english_speaker, :eligible, :not_a_veteran, :needs_accommodation) }
   let!(:traveler) { FactoryGirl.create :user }
+  let(:guest) { FactoryGirl.create :guest }
 
   it { should have_many :trips }
   it { should have_and_belong_to_many :accommodations }
@@ -48,5 +49,14 @@ RSpec.describe User, type: :model do
     expect(traveler.accommodations.where(code: "wheelchair").count).to eq(1)
     expect(traveler.accommodations.where(code: "jacuzzi").count).to eq(0)
   end
+
+  it 'is a guest' do
+    expect(guest.guest?).to be true
+  end
+
+  it 'is not a guest' do
+    expect(traveler.guest?).to be false
+  end
+
 
 end


### PR DESCRIPTION
If no user is passed on the plan call, create a guest user.  Guest users have emails that end with @example.com 

Guest users are needed to track eligibilities/accommodations for visitors.

The plan call will return the email/token for the new guest user.  The UI will need to be updated to work with OCC as this is a new call.