### PR TITLE
Support old api/v1 way of saving preferred modes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,7 +76,7 @@ class User < ApplicationRecord
     update_basic_attributes params[:attributes] unless params[:attributes].nil?
     update_eligibilities params[:characteristics] unless params[:characteristics].nil?
     update_accommodations params[:accommodations] unless params[:accommodations].nil?
-    update_preferred_modes params[:preferred_modes] unless params[:preferred_modes].nil? #This is depracated after api/v1. Preferred Modes are updated as part of attributes
+    update_preferred_modes params[:preferred_modes] unless params[:preferred_modes].blank? #This is depracated after api/v1. Preferred Modes are updated as part of attributes
     return true
   end
 
@@ -127,6 +127,7 @@ class User < ApplicationRecord
 
   def update_preferred_modes params
     self.preferred_trip_types = params.map{ |m| m.to_s.gsub('mode_',"")}
+    self.save
   end
 
   # Returns the user's (count) past trips, in descending order of trip time

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,6 +76,7 @@ class User < ApplicationRecord
     update_basic_attributes params[:attributes] unless params[:attributes].nil?
     update_eligibilities params[:characteristics] unless params[:characteristics].nil?
     update_accommodations params[:accommodations] unless params[:accommodations].nil?
+    update_preferred_modes params[:preferred_modes] unless params[:preferred_modes].nil? #This is depracated after api/v1. Preferred Modes are updated as part of attributes
     return true
   end
 
@@ -122,6 +123,10 @@ class User < ApplicationRecord
 
     self.accommodations = user_accommodations
 
+  end
+
+  def update_preferred_modes params
+    self.preferred_trip_types = params.map{ |m| m.to_s.gsub('mode_',"")}
   end
 
   # Returns the user's (count) past trips, in descending order of trip time

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -30,12 +30,12 @@ module Api
       # This format is depracated after api/v1
       def preferred_modes
         #Add mode_ onto the front of the mode name.  This is done to support existing API/v1 instances.  It has been depracated
-        object.preferred_trip_types.map{ |m| "mode_{m}"}
+        object.preferred_trip_types.blank? ? [] : object.preferred_trip_types.map{ |m| "mode_#{m}"} 
       end
 
       # Returns preferred trip types (the new way [bicycle, paratransit, walk, etc.])
       def preferred_trip_types
-        object.preferred_trip_types
+        object.preferred_trip_types.blank? ? [] : object.preferred_trip_types
       end
 
     end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -5,7 +5,7 @@ module Api
 
       attributes  :email, :first_name, :last_name,
                   :lang, :characteristics, :accommodations,
-                  :preferred_modes
+                  :preferred_modes, :preferred_trip_types
 
       # Returns name of preferred locale, or nil if not set
       def lang
@@ -26,8 +26,15 @@ module Api
         accs
       end
 
-      # Returns a list of the user's preferred trip types
+      # Returns a list of the user's preferred trip types (The old way [mode_bicycle, mode_paratransit, etc.])
+      # This format is depracated after api/v1
       def preferred_modes
+        #Add mode_ onto the front of the mode name.  This is done to support existing API/v1 instances.  It has been depracated
+        object.preferred_trip_types.map{ |m| "mode_{m}"}
+      end
+
+      # Returns preferred trip types (the new way [bicycle, paratransit, walk, etc.])
+      def preferred_trip_types
         object.preferred_trip_types
       end
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -56,12 +56,18 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     parsed_response = JSON.parse(response.body)
     # There should be 2 preferred modes
     expect(parsed_response["preferred_modes"].count).to eq(2)
-    # transit should be preferred
-    expect('transit'.in? parsed_response["preferred_modes"]).to eq(true)
-    # unicycle should be preferred
-    expect('unicycle'.in? parsed_response["preferred_modes"]).to eq(true)
+    # transit should be preferred mode (Depracated after api/v1)
+    expect('mode_transit'.in? parsed_response["preferred_modes"]).to eq(true)
+    # transit should be preferred trip type
+    expect('transit'.in? parsed_response["preferred_trip_types"]).to eq(true)
+    # unicycle should be preferred (Depracated after api/v1)
+    expect('mode_unicycle'.in? parsed_response["preferred_modes"]).to eq(true)
+    # unicycle should be preferred trip type
+    expect('unicycle'.in? parsed_response["preferred_trip_types"]).to eq(true)
+    # it should not include car (Depracated after api/v1)
+    expect('mode_car'.in? parsed_response["preferred_modes"]).to eq(false)
     # it should not include car
-    expect('car'.in? parsed_response["preferred_modes"]).to eq(false)
+    expect('car'.in? parsed_response["preferred_trip_types"]).to eq(false)
   end
 
   it 'returns the users eligibilities' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,6 +50,17 @@ RSpec.describe User, type: :model do
     expect(traveler.accommodations.where(code: "jacuzzi").count).to eq(0)
   end
 
+  #Depracated after api/v1
+  it 'updates_preferred_modes' do
+    params = {attributes: {first_name: "George", last_name: "Burdell", email: "gpburdell@email.com", lang: "en"}, preferred_modes: ['recumbent_bicycle', 'roller_blades']}
+    traveler.update_profile params
+    expect(traveler.email).to eq('gpburdell@email.com')
+    expect(traveler.first_name).to eq('George')
+    expect(traveler.last_name).to eq('Burdell')
+    expect(traveler.locale).to eq(Locale.find_by(name: "en"))
+    expect(traveler.preferred_trip_types).to eq(['recumbent_bicycle', 'roller_blades'])
+  end
+
   it 'is a guest' do
     expect(guest.guest?).to be true
   end

--- a/spec/serializers/api/v1/user_serializer_spec.rb
+++ b/spec/serializers/api/v1/user_serializer_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Api::V1::UserSerializer, type: :serializer do
 
   it "serializes traveler's preferred language and modes" do
     expect(eng_traveler_serialization["lang"]).to eq(english_traveler.preferred_locale.name)
-    expect(eng_traveler_serialization["preferred_modes"].to_a).to eq(english_traveler.preferred_trip_types)
+    expect(eng_traveler_serialization["preferred_modes"].to_a).to eq(english_traveler.preferred_trip_types.map{ |m| "mode_#{m}"})
+    expect(eng_traveler_serialization["preferred_trip_types"].to_a).to eq(english_traveler.preferred_trip_types)
   end
 
   it 'returns the eligibilities_hash' do


### PR DESCRIPTION
need to support preferred_modes updating and retrieving the old api/v1 way.  