### PR TITLE
Return all Accs and Eligs on the User Profile Call in API/V2

### DIFF
--- a/app/models/concerns/characteristics_helper.rb
+++ b/app/models/concerns/characteristics_helper.rb
@@ -42,11 +42,12 @@ module CharacteristicsHelper
     SimpleTranslationEngine.set_translation(locale, "#{self.class.name.downcase}_#{self.code}_#{translation}", value)
   end
   
-  def to_hash
+  def to_hash locale=:en
     {
-      name: self.try(:name),
+      name: self.try(:name, locale),
       code: self.try(:code),
-      note: self.try(:note)
+      note: self.try(:note, locale),
+      question: self.try(:question, locale)
     }
   end
 

--- a/app/models/trip_planner.rb
+++ b/app/models/trip_planner.rb
@@ -64,7 +64,7 @@ class TripPlanner
     # Pull out the relevant purposes, eligbilities, and accommodations of these services
     @relevant_purposes = (@available_services.collect { |service| service.purposes }).flatten.uniq
     @relevant_eligibilities = (@available_services.collect { |service| service.eligibilities }).flatten.uniq
-    @relevant_accommodations = (@available_services.collect { |service| service.accommodations }).flatten.uniq
+    @relevant_accommodations = Accommodation.all
 
     # Now finish filtering by purpose, eligibility, and accommodation
     @available_services = @available_services.available_for(@trip, only_by: [:purpose, :eligibility, :accommodation])

--- a/app/serializers/api/v2/user_serializer.rb
+++ b/app/serializers/api/v2/user_serializer.rb
@@ -14,7 +14,7 @@ module Api
       # Returns a list of the user's eligibilities
       def eligibilities
         Eligibility.all.map { 
-          |elig| elig.to_hash(object.preferred_locale.name).merge(
+          |elig| elig.to_hash(object.preferred_locale.try(:name)).merge(
             { 
               value: 
                 UserEligibility.find_by(eligibility: elig, user: object).try(:value)
@@ -25,7 +25,7 @@ module Api
       # Returns a list of the user's accommodations
       def accommodations
         Accommodation.all.map { 
-          |acc| acc.to_hash(object.preferred_locale.name).merge(
+          |acc| acc.to_hash(object.preferred_locale.try(:name)).merge(
             { 
               value: (acc.in? object.accommodations)
             }

--- a/app/serializers/api/v2/user_serializer.rb
+++ b/app/serializers/api/v2/user_serializer.rb
@@ -13,12 +13,23 @@ module Api
 
       # Returns a list of the user's eligibilities
       def eligibilities
-        object.user_eligibilities.map { |ue| ue.api_hash }
+        Eligibility.all.map { 
+          |elig| elig.to_hash(object.preferred_locale.name).merge(
+            { 
+              value: 
+                UserEligibility.find_by(eligibility: elig, user: object).try(:value)
+            }
+          )}
       end
 
       # Returns a list of the user's accommodations
       def accommodations
-        object.accommodations.map { |acc| acc.api_hash(object.locale) }
+        Accommodation.all.map { 
+          |acc| acc.to_hash(object.preferred_locale.name).merge(
+            { 
+              value: (acc.in? object.accommodations)
+            }
+          )}
       end
 
       def preferred_locale

--- a/spec/controllers/api/v1/trips_controller_spec.rb
+++ b/spec/controllers/api/v1/trips_controller_spec.rb
@@ -234,6 +234,14 @@ RSpec.describe Api::V1::TripsController, type: :controller do
     expect(response_body["trips"].count).to eq(0)
   end
 
+  it 'sends back all accommodations when planning a trip' do
+    post :create, params: plan_call_params
+    response_body = JSON.parse(response.body)
+
+    expect(response).to be_success
+    expect(response_body["accommodations"].count).to eq(Accommodation.count)
+  end
+
   # it 'sends back itineraries for multiple trips' do
   #   # Stub out trip creation because itinerary planning happens in TripPlanner
   #   allow(Trip).to receive(:create) { [trip, trip] }

--- a/spec/controllers/api/v2/users_controller_spec.rb
+++ b/spec/controllers/api/v2/users_controller_spec.rb
@@ -119,6 +119,8 @@ RSpec.describe Api::V2::UsersController, type: :controller do
     request.headers['X-User-Email'] = traveler.email
     get :show, format: :json
 
+    puts JSON.parse(response.body).ai 
+
     # test for the 200 status-code
     expect(response).to be_success
 
@@ -218,6 +220,68 @@ RSpec.describe Api::V2::UsersController, type: :controller do
     expect(jacuzzi_entry['name']).to eq('missing key accommodation_jacuzzi_name') # Just make sure we are making the call to get a name
     expect(jacuzzi_entry['note']).to eq('missing key accommodation_jacuzzi_note') # Just make sure we are making the call to get a note
     expect(jacuzzi_entry['question']).to eq('missing key accommodation_jacuzzi_question') # Just make sure we are making the call to get a question
+  end 
+
+  it 'returns the accommodations as false if they are not answered' do
+    sign_in english_traveler
+
+    # Set the users accommodations
+    english_traveler.update_accommodations({wheelchair: true, jacuzzi: false})
+
+    request.headers['X-User-Token'] = english_traveler.authentication_token
+    request.headers['X-User-Email'] = english_traveler.email
+    get :show, format: :json
+
+    # test for the 200 status-code
+    expect(response).to be_success
+
+    # Should be 1 Eligibility Question Answered
+    parsed_response = JSON.parse(response.body)["data"]["user"]
+    expect(parsed_response["accommodations"].count).to eq(2)
+
+    # The entries should be for wheelchair and jacuzzi, pull those out and confirm that
+    accommodations = parsed_response["accommodations"]
+    wheelchair_entry = accommodations.find { |i| i['code'] == 'wheelchair' }
+    jacuzzi_entry = accommodations.find { |i| i['code'] == 'jacuzzi' }
+    
+    # He needs space for a wheelchair
+    expect(wheelchair_entry['code']).to eq('wheelchair')
+    expect(wheelchair_entry['value']).to eq(true)
+
+    # gotta have that Jacuzzi
+    expect(jacuzzi_entry['code']).to eq('jacuzzi')
+    expect(jacuzzi_entry['value']).to eq(false)
+    expect(jacuzzi_entry['name']).to eq('missing key accommodation_jacuzzi_name') # Just make sure we are making the call to get a name
+    expect(jacuzzi_entry['note']).to eq('missing key accommodation_jacuzzi_note') # Just make sure we are making the call to get a note
+    expect(jacuzzi_entry['question']).to eq('missing key accommodation_jacuzzi_question') # Just make sure we are making the call to get a question
+  end 
+
+  it 'returns the users eligibilities as null if they are not answered' do
+    sign_in english_traveler
+    # Set the users eligibilities
+    english_traveler.update_eligibilities({over_65: true})
+
+    request.headers['X-User-Token'] = english_traveler.authentication_token
+    request.headers['X-User-Email'] = english_traveler.email
+    get :show, format: :json
+
+    # test for the 200 status-code
+    expect(response).to be_success
+
+    # Should be 2 Eligibility Questions Answered
+    parsed_response = JSON.parse(response.body)["data"]["user"]
+    expect(parsed_response["eligibilities"].count).to eq(2)
+
+    # It should be over_65 and the value should be true
+    expect(parsed_response["eligibilities"].first['code']).to eq('over_65')
+    expect(parsed_response["eligibilities"].first['value']).to eq(true)
+    expect(parsed_response["eligibilities"].first['name']).to eq('missing key eligibility_over_65_name') # Just make sure we are making the call to get a name
+    expect(parsed_response["eligibilities"].first['note']).to eq('missing key eligibility_over_65_note') # Just make sure we are making the call to get a note
+    expect(parsed_response["eligibilities"].first['question']).to eq('missing key eligibility_over_65_question') # Just make sure we are making the call to get a question
+
+    # It should NOT be a veteran
+    expect(parsed_response["eligibilities"].last['code']).to eq('veteran')
+    expect(parsed_response["eligibilities"].last['value']).to eq(nil)
   end 
 
   it 'updates basic attributes for a user' do

--- a/spec/controllers/api/v2/users_controller_spec.rb
+++ b/spec/controllers/api/v2/users_controller_spec.rb
@@ -119,8 +119,6 @@ RSpec.describe Api::V2::UsersController, type: :controller do
     request.headers['X-User-Email'] = traveler.email
     get :show, format: :json
 
-    puts JSON.parse(response.body).ai 
-
     # test for the 200 status-code
     expect(response).to be_success
 


### PR DESCRIPTION
All possible eligibilities and accommodations should be returned in the user profile call.

If an eligibility is unanswered, it's value should be nil. If an accommodation is unanswered, it's value should be false.