### PR TITLE
Log Api Requests to the DB

### DIFF
--- a/app/models/request_log.rb
+++ b/app/models/request_log.rb
@@ -1,0 +1,6 @@
+# Model for storing information about API controller requests
+class RequestLog < ApplicationRecord
+  
+  serialize :params
+  
+end

--- a/app/services/api_request_logger.rb
+++ b/app/services/api_request_logger.rb
@@ -1,0 +1,61 @@
+# Service object for Logging requests made to API Controllers
+class ApiRequestLogger
+  
+  attr_reader :include_controllers, :exclude_controllers, :exclude_actions
+  
+  # Accepts an options hash to configure which actions to log.
+  # *** OPTIONS: ***
+  # => include_controllers: Pass an array of strings which are either controller
+  # class names or substrings of those names. Will only log requests to controllers
+  # that match one of the names on the list. Defaults to 'Api::'.
+  # => exclude_controllers: Pass an array of controller name strings/substrings.
+  # Will not log requests to any of those controllers.
+  # => exclude_actions: Pass a hash with keys that are controller names, and 
+  # values that are arrays of action names to be excluded for that controller.
+  def initialize(opts={})
+    
+    # By default, only log requests for Api-namespaced controllers.
+    # Do not exclude any controllers or controller actions.
+    @include_controllers = opts[:include_controllers] || ["Api::"]
+    @exclude_controllers = opts[:exclude_controllers] || []
+    @exclude_actions = Hash.new([]).merge(opts[:exclude_actions] || {})
+  end
+  
+  # Start logging requests
+  def start
+    
+    # Subscribes to an event that occurs whenever a controller request is made
+    ActiveSupport::Notifications.subscribe 'process_action.action_controller' do |*args|
+      event = ActiveSupport::Notifications::Event.new(*args)
+      payload = event.payload
+      
+      # The controller and action are included and not excluded, create a 
+      # RequestLog object for the request.
+      if log?(payload[:controller], payload[:action])
+        RequestLog.create({
+          controller: payload[:controller],
+          action: payload[:action],
+          params: payload[:params],
+          status_code: payload[:status],
+          auth_email: payload[:headers]["X-User-Email"],
+          duration: event.duration.to_i
+        })
+      end
+      
+    end
+  end
+
+  # Stop logging requests
+  def stop
+    ActiveSupport::Notifications.unsubscribe 'process_action.action_controller'
+  end
+  
+  # Pass it a controller class name and action name, and returns boolean for 
+  # whether or not that class and action should be logged
+  def log?(controller_class_name, action_name)
+    @include_controllers.any? { |ctrl| controller_class_name.include?(ctrl) } &&
+    @exclude_controllers.none? { |ctrl| controller_class_name.include?(ctrl) } &&
+    @exclude_actions[controller_class_name].exclude?(action_name)
+  end
+  
+end

--- a/config/initializers/api_request_logging.rb
+++ b/config/initializers/api_request_logging.rb
@@ -1,0 +1,8 @@
+
+# Creates an ApiRequestLogger, configured to log all requests to Api:: namespaced
+# controllers. May add controllers and/or specific actions to exclude, if desired.
+# See api_request_logger.rb for more details.
+ApiRequestLogger.new(
+  exclude_controllers: [],
+  exclude_actions: {}
+).start

--- a/db/migrate/20171121180334_create_request_logs.rb
+++ b/db/migrate/20171121180334_create_request_logs.rb
@@ -1,0 +1,17 @@
+class CreateRequestLogs < ActiveRecord::Migration[5.0]
+  def change
+    create_table :request_logs do |t|
+      t.string :controller
+      t.string :action
+      t.string :status_code
+      t.text :params
+      t.string :auth_email
+      t.integer :duration
+
+      t.timestamps
+    end
+    
+    # Index on controller then on action, rather than just on action
+    add_index :request_logs, [:controller, :action]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171120144938) do
+ActiveRecord::Schema.define(version: 20171121180334) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -277,6 +277,18 @@ ActiveRecord::Schema.define(version: 20171120144938) do
     t.datetime "created_at",                                               null: false
     t.datetime "updated_at",                                               null: false
     t.geometry "geom",       limit: {:srid=>4326, :type=>"multi_polygon"}
+  end
+
+  create_table "request_logs", force: :cascade do |t|
+    t.string   "controller"
+    t.string   "action"
+    t.string   "status_code"
+    t.text     "params"
+    t.string   "auth_email"
+    t.integer  "duration"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.index ["controller", "action"], name: "index_request_logs_on_controller_and_action", using: :btree
   end
 
   create_table "roles", force: :cascade do |t|

--- a/spec/controllers/api/v2/trips_controller_spec.rb
+++ b/spec/controllers/api/v2/trips_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V2::TripsController, type: :controller do
   
   # Create necessary configs, purposes, and characteristics
-  before(:each) do 
+  before(:each) do
     create(:otp_config)
     create(:tff_config)
     create(:uber_token)
@@ -97,6 +97,24 @@ RSpec.describe Api::V2::TripsController, type: :controller do
       expect(created_trip.relevant_purposes).to eq(Purpose.all)
       expect(created_trip.relevant_accommodations).to eq(Accommodation.all)
       expect(created_trip.relevant_eligibilities).to eq(Eligibility.all)
+    end
+    
+    # Spot check if the ApiRequestLogger is working properly
+    it "logs api requests" do
+      request_logs_count = RequestLog.count
+      
+      request.headers.merge!(user_headers)
+      post :create, params: plan_call_params
+      
+      expect(RequestLog.count).to eq(request_logs_count + 1)
+      
+      log = RequestLog.last
+      
+      expect(log.status_code).to eq('200')
+      expect(log.controller).to eq("Api::V2::TripsController")
+      expect(log.action).to eq("create")
+      expect(log.auth_email).to eq(user.email)
+      expect(log.params).to be
     end
     
   end

--- a/spec/factories/request_logs.rb
+++ b/spec/factories/request_logs.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :request_log do
+    controller "MyString"
+    action "MyString"
+    params "MyText"
+    auth_email "MyString"
+    duration 1
+  end
+end

--- a/spec/models/request_log_spec.rb
+++ b/spec/models/request_log_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe RequestLog, type: :model do
+  it { should respond_to :controller, :action, :status_code, 
+                         :params, :auth_email, :duration, :created_at }
+end


### PR DESCRIPTION
Any time a request is made to an Api::V1 or Api::V2 controller, we now store info about the request in the RequestLog table.