### PR TITLE
Modify Guest User Auth for API Calls

### DIFF
--- a/app/controllers/api/v1/trips_controller.rb
+++ b/app/controllers/api/v1/trips_controller.rb
@@ -4,7 +4,7 @@ module Api
       before_action :require_authentication, only: [
         :past_trips, :future_trips, :select, :cancel, :index, :book
       ]
-      before_action :ensure_traveler, only: [:create] #If @traveler is not set, then create a guest user account
+      before_action :allow_authentication, only: [:create] #If @traveler is not set, then create a guest user account
 
       # GET trips/past_trips
       # Returns past trips associated with logged in user, limit by max_results param

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class UsersController < ApiController
       before_action :require_authentication, only: [:update]
-      before_action :ensure_traveler, only: [:get_guest_token] #If @traveler is not set, then create a guest user account
+      before_action :allow_authentication, only: [:get_guest_token] #If @traveler is not set, then create a guest user account
 
       # Sends back a profile hash via the API::V1::UserSerializer
       def profile
@@ -36,6 +36,7 @@ module Api
 
       # Used by API/v1 to create guest users on command
       def get_guest_token
+        @traveler.ensure_authentication_token # Guest users do not have an auth token by default, so we must generate one
         render status: 200, json: {email: @traveler.email, authentication_token: @traveler.authentication_token}
       end
 

--- a/app/controllers/api/v2/trips_controller.rb
+++ b/app/controllers/api/v2/trips_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V2
     class TripsController < ApiController
-      before_action :ensure_traveler, only: [:create] #If @traveler is not set, then create a guest user account
+      before_action :allow_authentication, only: [:create] #If @traveler is not set, then create a guest user account
 
       # POST trips/
       # POST trips/plan

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -3,7 +3,9 @@ module Api
     class UsersController < ApiController
       # include Devise::Controllers::SignInOut
       
-      before_action :require_authentication, except: [:create, :new_session, :reset_password]
+      # before_action :require_authentication, except: [:create, :new_session, :reset_password]
+      before_action :require_authentication, only: [:end_session, :destroy]
+      before_action :allow_authentication, only: [:show, :update]
 
       # Get the user profile 
       def show

--- a/spec/controllers/api/api_controller_spec.rb
+++ b/spec/controllers/api/api_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Api::ApiController, type: :controller do
   it 'recognizes guest user email and sets @traveler' do
     expect(controller.traveler).to be_nil
     request.headers.merge!(guest_request_headers)
-    controller.ensure_traveler
+    controller.allow_authentication
     expect(controller.traveler.email).to eq(request.headers["X-User-Email"])
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -105,6 +105,15 @@ RSpec.describe User, type: :model do
   ### ROLES & CANCAN ABILITIES ###
   describe 'abilities & roles' do
     
+    it "generates an auth token automatically on save" do
+      expect(traveler.authentication_token).to be
+      old_auth_token = traveler.authentication_token
+      traveler.update_attributes(authentication_token: nil)
+      traveler.reload
+      expect(traveler.authentication_token).to be
+      expect(traveler.authentication_token).not_to eq(old_auth_token)
+    end
+    
     describe "admin users" do
       
       let(:admin) { create(:admin) }
@@ -236,6 +245,13 @@ RSpec.describe User, type: :model do
       
       # shouldn't be able to do anything, this is just a test example
       it{ should_not  be_able_to(:read, Service) }
+      
+      it "does NOT automatically generate an auth token" do
+        expect(guest.authentication_token).to be_nil
+        guest.save
+        guest.reload
+        expect(guest.authentication_token).to be_nil
+      end
       
     end
     


### PR DESCRIPTION
- Guest users do not automatically generate tokens
- Sending just a guest user's email in auth headers is sufficient, no token required
- Sending a non-guest user's email but no (or bad) token will yield a 401 even if guest users are allowed