### PR TITLE
Pamf 673 trip reminders

### DIFF
--- a/app/controllers/api/v1/trips_controller.rb
+++ b/app/controllers/api/v1/trips_controller.rb
@@ -38,6 +38,7 @@ module Api
             external_purpose = params[:trip_purpose]
             start_location = trip_location_to_google_hash(trip[:start_location])
             end_location = trip_location_to_google_hash(trip[:end_location])
+            details = trip[:details] || Trip::DEFAULT_TRIP_DETAILS
             trip_params(ActionController::Parameters.new({
               trip: {
                 origin_attributes: start_location,
@@ -46,7 +47,8 @@ module Api
                 arrive_by: (trip[:departure_type] == "arrive"),
                 user_id: @traveler && @traveler.id,
                 purpose_id: purpose ? purpose.id : nil,
-                external_purpose: external_purpose
+                external_purpose: external_purpose,
+                details: details
               }
             }))
           end
@@ -189,6 +191,22 @@ module Api
       
       end
 
+      # Method does batch updates to round trips
+      # - trip details are merged with the current details
+      def update_trip_details
+        params.permit({details: details_attributes}, :trip)
+        params.require(:trip)
+        @trips = Trip.where(["id = :trip_id or previous_trip_id = :trip_id", { trip_id: params[:trip] } ])
+        if !@trips.empty?
+          @trips.each do |trip|
+            trip.update(details: trip.details.merge(params[:details]))
+          end
+          render status:200, json:{trip: @trips}
+        else
+          render status:404, json: nil
+        end
+      end
+
       # POST trips/cancel, itineraries/cancel
       # Unselects and cancels the target itinerary
       def cancel
@@ -285,12 +303,17 @@ module Api
         parameters.require(:trip).permit(
           {origin_attributes: place_attributes},
           {destination_attributes: place_attributes},
+          {details: details_attributes},
           :trip_time,
           :arrive_by,
           :user_id,
           :purpose_id,
           :external_purpose
         )
+      end
+
+      def details_attributes
+        [:notification_preferences]
       end
 
       def place_attributes
@@ -328,6 +351,7 @@ module Api
         # Trip attributes
         trip_hash = {
           trip_id: trip.id,
+          details: trip.details,
           origin: WaypointSerializer.new(trip.origin).to_hash,
           destination: WaypointSerializer.new(trip.destination).to_hash
         }

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -116,6 +116,25 @@ class UserMailer < ApplicationMailer
     mail(to: addresses, subject: subject)
   end
 
+  def user_trip_reminder(addresses,trip,days_away)
+    @days_away = days_away
+    @trip = trip
+    @traveler = @trip.user
+    @locale = @traveler.locale.try(:name)
+    subject = "FindMyRidePA Trip Reminder!"
+    @itinerary = @trip.selected_itinerary
+    unless @itinerary
+      return
+    end
+    if @itinerary.service and @itinerary.service.logo.url
+      attachments.inline['service_logo.png'] = open(ActionController::Base.helpers.asset_path(@itinerary.service.logo.thumb.url.to_s), 'rb').read
+    end
+    map_image = MapService.new(@itinerary).create_static_map
+    attachments.inline[@itinerary.id.to_s + ".png"] = open(map_image, 'rb').read
+    attach_standard_icons #TODO: Don't attach all icons by default.  Attach them as needed.
+    mail(to: addresses, subject: subject)
+  end
+
   private
 
   # Attaches an asset to the email based on its filename (including extension)

--- a/app/models/concerns/booking_helpers.rb
+++ b/app/models/concerns/booking_helpers.rb
@@ -29,7 +29,7 @@ module BookingHelpers
     end
 
     def sync days_ago=1
-      booking_profiles.each do |bp|
+      booking_profiles.valid_service.each do |bp|
         bp.booking_ambassador.sync(days_ago)
       end
     end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -13,8 +13,12 @@ class Config < ApplicationRecord
     :get_ride_pilot_purposes,
     :feedback_reminders,
     :purge_unused_guests,
-    :sync_all_ecolane_users_3_days
+    :sync_all_ecolane_users_3_days,
+    :send_fixed_trip_reminders
   ].freeze
+
+  # Default notification preferences for users, freezing for now
+  DEFAULT_NOTIFICATION_PREFS = [7,3,1].freeze
 
   # Returns the value of a setting when you say Config.<key>
   def self.method_missing(key, *args, &blk)

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -14,7 +14,8 @@ class Config < ApplicationRecord
     :feedback_reminders,
     :purge_unused_guests,
     :sync_all_ecolane_users_3_days,
-    :send_fixed_trip_reminders
+    :send_fixed_trip_reminders,
+    :add_notification_preferences
   ].freeze
 
   # Default notification preferences for users, freezing for now

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -29,6 +29,7 @@ class Trip < ApplicationRecord
   accepts_nested_attributes_for :destination
   
   before_validation :set_trip_time
+  serialize :details
 
   write_to_csv with: Admin::TripsReportCSVWriter
 
@@ -38,7 +39,7 @@ class Trip < ApplicationRecord
   ### CONSTANTS ###
   # Constant list of trip types that can be planned.
   TRIP_TYPES = [:transit, :paratransit, :taxi, :walk, :car, :bicycle, :uber, :lyft]
-
+  DEFAULT_TRIP_DETAILS = { notification_preferences: nil}
 
   ### SCOPES ###
 
@@ -55,6 +56,8 @@ class Trip < ApplicationRecord
   scope :past, -> { where('trip_time < ?', DateTime.now.in_time_zone - 6.hours).order('trip_time DESC') }
   scope :past_14_days, -> { where('trip_time >= ?', DateTime.now.in_time_zone - 6.hours - 14.days).order('trip_time DESC') }
   scope :future, -> { where('trip_time >= ?', DateTime.now.in_time_zone - 6.hours).order('trip_time ASC') }
+
+  # Select trips that are saved
   scope :selected, -> { where.not(selected_itinerary_id: nil) }
 
   # Geographic scopes return trips that start or end in the passed geom
@@ -69,6 +72,20 @@ class Trip < ApplicationRecord
   scope :with_purpose, -> (purpose_ids) do
     where(id: joins(:purpose).where(purposes: { id: purpose_ids }).pluck(:id))
   end
+
+  # Return trips that are transit trips
+  scope :transit_trips, -> {
+    joins('inner join itineraries on itineraries.id = trips.selected_itinerary_id').where({ 'itineraries.trip_type': 'transit'})
+  }
+
+  # Return trips in the next n days
+  # Note: this is not selecting trips that are in 7 days or less from now
+  scope :in_next_n_days, ->(n_days) {
+                            where({
+                                  trip_time: (
+                                    (DateTime.now.midnight.in_time_zone.to_time + n_days * 60 * 24).to_datetime.midnight..
+                                      (DateTime.now.midnight.in_time_zone.to_time + (n_days + 1) * 60 * 60 * 24).to_datetime.midnight),
+                                })}
   
   # Scopes based on trip linkages
   scope :outbound, -> do # Outbound trips: the first leg
@@ -99,7 +116,6 @@ class Trip < ApplicationRecord
   def self.ods
     pluck(:origin_id, :destination_id).flatten.compact.uniq
   end
-
 
   ### INSTANCE METHODS ###
   def unselect

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,6 +52,7 @@ class User < ApplicationRecord
   has_many :stomping_grounds
   has_many :user_alerts, dependent: :destroy
   has_many :alerts, through: :user_alerts
+  has_many :user_booking_profiles
 
 
   # These associations allow us to pull just the confirmed or just the denied eligibilities (e.g. ones with true or false values)

--- a/app/models/user_booking_profile.rb
+++ b/app/models/user_booking_profile.rb
@@ -12,7 +12,10 @@ class UserBookingProfile < ApplicationRecord
   
   ### VALIDATIONS ###
   validates :user_id, presence: true
-  
+
+  ### SCOPES ###
+  scope :valid_service, -> {where.not(service_id: nil)}
+
   ### INSTANCE METHODS ###
   
   # Returns the appropriate booking ambassador based on the booking_api field

--- a/app/serializers/api/v1/trip_serializer.rb
+++ b/app/serializers/api/v1/trip_serializer.rb
@@ -4,7 +4,7 @@ module Api
     class TripSerializer < ActiveModel::Serializer
 
       attributes  :id, :trip_id, :user_id, :arrive_by, :trip_time,
-                  :accommodations, :characteristics, :purposes, :new_guest_user, :itineraries
+                  :accommodations, :characteristics, :purposes, :new_guest_user, :itineraries, :details
       #has_many :itineraries
       belongs_to :origin
       belongs_to :destination
@@ -46,6 +46,10 @@ module Api
         else
           nil
         end
+      end
+
+      def details
+        object.details || nil
       end
 
     end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -5,7 +5,8 @@ module Api
 
       attributes  :email, :first_name, :last_name,
                   :lang, :characteristics, :accommodations,
-                  :preferred_modes, :preferred_trip_types
+                  :preferred_modes, :preferred_trip_types, :details
+
 
       # Returns name of preferred locale, or nil if not set
       def lang
@@ -36,6 +37,10 @@ module Api
       # Returns preferred trip types (the new way [bicycle, paratransit, walk, etc.])
       def preferred_trip_types
         object.preferred_trip_types.blank? ? [] : object.preferred_trip_types
+      end
+
+      def details
+        object.user_booking_profiles.where(service_id: nil).pluck(:details).first
       end
 
     end

--- a/app/views/user_mailer/user_trip_reminder.html.haml
+++ b/app/views/user_mailer/user_trip_reminder.html.haml
@@ -1,0 +1,47 @@
+// The Origin/Destination header
+
+%h1{style: 'text-align:left'}
+  ="Your booked FindMyRidePA trip for #{@itinerary.start_time.in_time_zone.strftime("%A, %B %-d")} is coming up in #{@days_away} days!"
+%h2{style: 'text-align:left'}
+  ="See below for trip details:"
+%br
+
+-unless @itinerary.service.nil?
+  = render :partial => "service_summary_header", :locals => { :itinerary => @itinerary }
+  %br
+%p
+  ="Hello! Your trip on #{@itinerary.start_time.in_time_zone.strftime("%A, %B %-d")} is coming up! Here are the details for your trip!"
+%table.trip_header{style: "font-size:1.0em; padding: 12px 0px; font-family: 'Helvetica Neue', Arial;"}
+  %tr
+    %td{style: "color:grey; padding-right: 10px;"}
+      %strong.trip_header_detail
+        = "#{translate('api_v1.emails.user_trip.origin')}: "
+    %td{style: "padding-right: 10px;"}
+      %strong.trip_header_detail
+        =@trip.origin.to_s
+  %tr
+    %td{style: "color:grey; weight:strong; padding-right: 10px;"}
+      %strong.trip_header_detail
+        ="#{translate('api_v1.emails.user_trip.destination')}: "
+    %td{style: "padding-right: 10px;"}
+      %strong.trip_header_detail
+        =@trip.destination.to_s
+  %tr
+    %td{style: "color:grey; padding-right: 10px;"}
+      %strong.trip_header_detail
+        ="#{translate('api_v1.emails.user_trip.date')}: "
+    %td{style: "padding-right: 10px;"}
+      %strong
+        =@itinerary.start_time.in_time_zone.strftime("%A, %B %-d")
+
+// Summary of Itinerary Info
+= render :partial => 'trip_summary_header', :locals => { :itinerary => @itinerary }
+
+// Detailed Itinerary Info
+-unless @itinerary.trip_type.in? ['taxi', 'uber', 'paratransit', 'lyft']
+  = render :partial => "static_details", :locals => { :itinerary => @itinerary }
+
+// Static Map
+%td{style: "text-align: center;", colspan: 2}
+  %div{style: "width:100%;background: white; border-radius: 5px; padding: 10px;"}
+    =image_tag(attachments[@itinerary.id.to_s + ".png"].url)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,5 +73,7 @@ Rails.application.configure do
     # Should largely be okay to build this here since this is only tracking db migrations
     # and rake tasks run in development by default
     config.db_logger = ActiveSupport::Logger.new("log/db_changes.log")
+    config.logger = ActiveSupport::Logger.new("log/#{Rails.env}.log")
+
   end
 end

--- a/config/initializers/log_db_changes.rb
+++ b/config/initializers/log_db_changes.rb
@@ -12,7 +12,6 @@ if ENV['RAILS_LOG_TO_STDOUT']
     end
     rescue
       puts "Database logging failed"
-      return
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
       end
       get 'trips/past_trips' => 'trips#past_trips'
       get 'trips/future_trips' => 'trips#future_trips'
+      put 'itineraries/update_trip_details' => 'trips#update_trip_details'
       # post 'trips/past_trips' => 'trips#index'
       post 'itineraries/plan' => 'trips#create'
       post 'itineraries/select' => 'trips#select'

--- a/db/migrate/20210408144409_add_trip_details_column.rb
+++ b/db/migrate/20210408144409_add_trip_details_column.rb
@@ -1,0 +1,5 @@
+class AddTripDetailsColumn < ActiveRecord::Migration[5.0]
+  def change
+    add_column :trips, :details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191108152422) do
+ActiveRecord::Schema.define(version: 20210408144409) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -441,6 +441,7 @@ ActiveRecord::Schema.define(version: 20191108152422) do
     t.integer  "purpose_id"
     t.integer  "previous_trip_id"
     t.string   "external_purpose"
+    t.text     "details"
     t.index ["destination_id"], name: "index_trips_on_destination_id", using: :btree
     t.index ["origin_id"], name: "index_trips_on_origin_id", using: :btree
     t.index ["previous_trip_id"], name: "index_trips_on_previous_trip_id", using: :btree

--- a/lib/tasks/scheduled.rake
+++ b/lib/tasks/scheduled.rake
@@ -20,7 +20,8 @@ namespace :scheduled do
         fixed_route: [7,3,1]
       }
     }
-    User.all.each do |user|
+    # Fetch all registered travelers and build them a default booking profile
+    User.registered_travelers.each do |user|
       unless !user.user_booking_profiles.where(service_id: nil).empty? && !user.registered_traveler?
         user.user_booking_profiles.create({details: hash})
       end

--- a/lib/tasks/scheduled.rake
+++ b/lib/tasks/scheduled.rake
@@ -13,7 +13,7 @@ namespace :scheduled do
     Rake::Task["scheduled:sync_all_ecolane_users_X_days"].invoke(14)
   end
 
-  desc "TEMPORARY - Add notification preferences"
+  desc "Add notification preferences for users that don't have one already"
   task add_notification_preferences: :environment do
     hash = {
       notification_preferences: {
@@ -53,7 +53,7 @@ namespace :scheduled do
     puts "Starting #{ndays} day #{verbose ? "": "non-"}verbose Sync for #{count} users at #{task_start}" 
     User.all.order(:id).each do |u|
       user_start = Time.now
-      begin 
+      begin
         u.sync(ndays)
         users_processed += 1
         if verbose

--- a/lib/tasks/scheduled.rake
+++ b/lib/tasks/scheduled.rake
@@ -13,6 +13,20 @@ namespace :scheduled do
     Rake::Task["scheduled:sync_all_ecolane_users_X_days"].invoke(14)
   end
 
+  desc "TEMPORARY - Add notification preferences"
+  task add_notification_preferences: :environment do
+    hash = {
+      notification_preferences: {
+        fixed_route: [7,3,1]
+      }
+    }
+    User.all.each do |user|
+      unless !user.user_booking_profiles.where(service_id: nil).empty? && !user.registered_traveler?
+        user.user_booking_profiles.create({details: hash})
+      end
+    end
+  end
+
   desc "Sync all Ecolane Users back for 3 days"
   task sync_all_ecolane_users_3_days: :environment do
     Rake::Task["scheduled:sync_all_ecolane_users_X_days"].invoke(3,true)
@@ -212,5 +226,47 @@ namespace :scheduled do
       user.destroy if user.trips.count == 0
     end
   end
+
+  desc "Send Fixed Trip Reminders"
+  task send_fixed_trip_reminders: :environment do
+    count = 0
+    console_str = Config::DEFAULT_NOTIFICATION_PREFS.join(", ")
+    puts "Emailing notifications for trips: #{console_str} days away"
+
+    # For each default notification day, look for trips within that range
+    # NOTE: below algorithm assumes that the order of the fixed route trip notifications
+    # ...matches the order that the reminders in Config::DEFAULT_NOTIFICATION_PREFS are in
+    Config::DEFAULT_NOTIFICATION_PREFS.each.with_index do |default_day, index|
+
+      # Select all transit trips that are in the next n days
+      # so i.e transit trips that are in the next 7 days, 3 days, and 1 days
+      trips = Trip.transit_trips.in_next_n_days(default_day).distinct
+      trips.each do |trip|
+        # get user email
+        email = trip.user.to_s
+
+        details = trip.details
+        fixed_route = details[:notification_preferences][:fixed_route]
+        reminder = fixed_route[index]
+        # If the trip reminder is enabled and
+        # ...the trip reminder day is the same as the Config Notification Day, send an email
+        if reminder[:enabled] == true && reminder[:day] == default_day
+          UserMailer.user_trip_reminder(email,trip,default_day)
+
+          # toggle enable state of the
+          fixed_route[index][:enabled] = false
+
+          trip.update(details: details)
+          count += 1
+        else
+          # continue on without doing anything
+          next
+        end
+      end
+    end
+    puts "Trip reminder task completed, #{count} emails sent"
+  end
+
+
     
 end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -5,11 +5,15 @@ class UserMailerPreview < ActionMailer::Preview
   end
 
   def user_trip_email
-    UserMailer.user_trip_email(User.find(2), Trip.find(70))
+    UserMailer.user_trip_email(User.find(2), Trip.selected.transit_trips.first)
   end
 
   def ecolane_trip_email
-    UserMailer.ecolane_trip_email('wjiang@camsys.com', Booking.limit(5))
+    UserMailer.ecolane_trip_email(User.first.email, Booking.limit(5))
+  end
+
+  def user_trip_reminder
+    UserMailer.user_trip_reminder(User.first.email, Trip.selected.transit_trips.first, 7)
   end
 
 end


### PR DESCRIPTION
Add trip notification functionality to the backend. This includes several breaking changes
NOTE: this has an FMR component to it as well, see the following [Pull Request](https://github.com/camsys/applymyride/pull/24)

## Additions
- add a UserMailer method for sending out a single transit trip reminder
- add a email template for transit trip reminders
- add a route for updating trip details

## Breaking Changes
The below breaking changes have been introduced in this PR
- Add a Rails migration to add a details column to the Trips table

This will need to be integrated by running `bundle exec rake db:migrate` in the terminal