### PR TITLE
Occ 591 1.17.0

### DIFF
--- a/app/assets/stylesheets/admin/_general-styles.scss
+++ b/app/assets/stylesheets/admin/_general-styles.scss
@@ -6,3 +6,9 @@ div.checkbox,
 div.radio {
   padding-left: 15px;
 }
+
+.nav.navbar-right.navbar-nav {
+  display: flex;
+  justify-content: flex-end;
+  align-items: baseline
+}

--- a/app/controllers/admin/agencies_controller.rb
+++ b/app/controllers/admin/agencies_controller.rb
@@ -7,9 +7,7 @@ class Admin::AgenciesController < Admin::AdminController
       @agencies = @agencies.order(:name)
     elsif current_user.oversight_admin? ||current_user.oversight_staff?
       # Get all agencies associated with that oversight agency, and it'self
-      oa = current_user.staff_agency
-      tas = oa.agency_oversight_agency.pluck(:transportation_agency_id)
-      @agencies = Agency.where(id: [*tas,nil,current_user.staff_agency.id])
+      @agencies = current_user.accessible_agencies
     end
   end
   

--- a/app/controllers/admin/agencies_controller.rb
+++ b/app/controllers/admin/agencies_controller.rb
@@ -24,6 +24,8 @@ class Admin::AgenciesController < Admin::AdminController
       return
     end
     if @agency.update_attributes(agency_params)
+      @agency.type = @agency.agency_type.name
+      @agency.save
       AgencyOversightAgency.create(transportation_agency_id:@agency.id,
                                            oversight_agency_id: oversight_agency_id)
       flash[:success] = "Agency Created Successfully"

--- a/app/controllers/admin/agencies_controller.rb
+++ b/app/controllers/admin/agencies_controller.rb
@@ -73,7 +73,7 @@ class Admin::AgenciesController < Admin::AdminController
 
   def oversight_params
     oversight = params.delete(:oversight)
-    oversight[:oversight_agency_id]
+    oversight.try(:oversight_agency_id)
   end
 
   def agency_params

--- a/app/controllers/admin/agencies_controller.rb
+++ b/app/controllers/admin/agencies_controller.rb
@@ -7,7 +7,7 @@ class Admin::AgenciesController < Admin::AdminController
       @agencies = @agencies.order(:name)
     elsif current_user.oversight_admin? ||current_user.oversight_staff?
       # Get all agencies associated with that oversight agency, and it'self
-      @agencies = current_user.accessible_agencies
+      @agencies = current_user.accessible_agencies.order(:name)
     end
   end
   

--- a/app/controllers/admin/geographies_controller.rb
+++ b/app/controllers/admin/geographies_controller.rb
@@ -5,8 +5,9 @@ class Admin::GeographiesController < Admin::AdminController
     @counties = County.all.order(:state, :name)
     @cities = City.all.order(:state, :name)
     @zipcodes = Zipcode.all.order(:name)
-    @custom_geographies = CustomGeography.all.order(:name)
-    
+    @custom_geographies = get_geographies_for_user
+    @agencies = current_user.get_transportation_agencies_for_user.order(:name)
+
     check_for_missing_geometries(@counties, @cities, @zipcodes, @custom_geographies)
   end
 
@@ -42,15 +43,6 @@ class Admin::GeographiesController < Admin::AdminController
     present_error_messages(uploader)
     redirect_to admin_geographies_path
   end
-
-  def update_custom_geographies
-    custom_geography_params
-    cg = CustomGeography.find(custom_geography_params[:id])
-    agency = Agency.find(custom_geography_params[:agency])
-    cg.update(agency: agency)
-    flash[:success] = "Successfully updated #{cg.name}"
-    redirect_to admin_geographies_path
-  end
   
   # Serves JSON responses to geography searches to enable autocomplete
   def autocomplete
@@ -74,7 +66,31 @@ class Admin::GeographiesController < Admin::AdminController
     :id
     )
   end
-  
+
+  def get_geographies_for_user
+    if current_user.superuser?
+      CustomGeography.all.order(:name)
+    elsif current_user.staff_agency.transportation?
+      CustomGeography.where(agency_id: current_user.staff_agency.id).order(:name)
+    elsif current_user.currently_oversight? || current_user.currently_transportation?
+      CustomGeography.where(agency_id: current_user.current_agency.id).order(:name)
+    elsif current_user.staff_agency.oversight? && current_user.current_agency.nil?
+      CustomGeography.where(agency_id: nil).order(:name)
+    end
+  end
+
+  def get_agencies_for_current_user
+    if current_user.superuser?
+      TransportationAgency.all
+    elsif current_user.staff_agency.transportation?
+      [current_user.staff_agency]
+    elsif current_user.currently_transportation?
+      [current_user.current_agency]
+    elsif current_user.staff_agency.oversight? && current_user.current_agency.nil?
+      ta_ids = current_user.staff_agency.agency_oversight_agency.pluck(:transportation_agency_id)
+      TransportationAgency.where(id:ta_ids)
+    end
+  end
   protected
 
   def check_for_missing_geometries(*collections)

--- a/app/controllers/admin/geographies_controller.rb
+++ b/app/controllers/admin/geographies_controller.rb
@@ -79,18 +79,6 @@ class Admin::GeographiesController < Admin::AdminController
     end
   end
 
-  def get_agencies_for_current_user
-    if current_user.superuser?
-      TransportationAgency.all
-    elsif current_user.staff_agency.transportation?
-      [current_user.staff_agency]
-    elsif current_user.currently_transportation?
-      [current_user.current_agency]
-    elsif current_user.staff_agency.oversight? && current_user.current_agency.nil?
-      ta_ids = current_user.staff_agency.agency_oversight_agency.pluck(:transportation_agency_id)
-      TransportationAgency.where(id:ta_ids)
-    end
-  end
   protected
 
   def check_for_missing_geometries(*collections)

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -41,16 +41,19 @@ class Admin::ReportsController < Admin::AdminController
   end
   
   def planned_trips_dashboard
-    @trips = Trip.from_date(@from_date).to_date(@to_date)
+    @trips = current_user.get_trips_for_staff_user
+    @trips = @trips.from_date(@from_date).to_date(@to_date)
     @trips = @trips.partner_agency_in(@partner_agency) unless @partner_agency.blank?
   end
 
-  def unique_users_dashboard 
-    @user_requests = RequestLog.from_date(@from_date).to_date(@to_date)
+  def unique_users_dashboard
+    travelers_emails = current_user.get_travelers_for_staff_user.pluck(:email)
+    @user_requests = RequestLog.where(auth_email:travelers_emails).from_date(@from_date).to_date(@to_date)
   end
   
   def popular_destinations_dashboard
-    @trips = Trip.from_date(@from_date).to_date(@to_date)
+    @trips = current_user.get_trips_for_staff_user
+    @trips = @trips.from_date(@from_date).to_date(@to_date)
   end
   
   ### / graphical dashboards
@@ -76,15 +79,14 @@ class Admin::ReportsController < Admin::AdminController
     if current_user.superuser?
       @users = User.all
     elsif current_user.transportation_admin? ||current_user.transportation_staff?
-      @users = current_user.travelers_for_staff_agency
+      @users = User.querify(current_user.any_users_for_staff_agency + current_user.travelers_for_staff_agency)
     elsif current_user.currently_oversight?
-      @users = current_user.travelers_for_oversight_agency
+      @users = User.querify(current_user.any_users_for_staff_agency + current_user.travelers_for_oversight_agency)
     elsif current_user.currently_transportation?
-      @users = current_user.travelers_for_current_agency
+      @users = User.querify(current_user.any_users_for_current_agency + current_user.travelers_for_current_agency)
       # Fallback just in case an edge case is missed
     else
-      puts "Got to users report fallback, returning no users for #{current_user.email}"
-      @users = User.none
+      @users = current_user.travelers_for_none
     end
     @users = @users.registered unless @include_guests
     @users = @users.with_accommodations(@accommodations) unless @accommodations.empty?
@@ -98,21 +100,10 @@ class Admin::ReportsController < Admin::AdminController
   end
   
   def trips_table
-    if current_user.superuser?
-      @trips = Trip.all
-    elsif current_user.transportation_admin? ||current_user.transportation_staff?
-      @trips = Trip.with_transportation_agency(current_user.staff_agency.id)
-    elsif current_user.currently_oversight?
-      tas = AgencyOversightAgency.where(oversight_agency_id: current_user.staff_agency.id).pluck(:transportation_agency_id)
-      @trips = Trip.with_transportation_agency(tas)
-    elsif current_user.currently_transportation?
-      @trips = Trip.with_transportation_agency(current_user.current_agency.id)
-    elsif current_user.current_agency.nil?
-      @trips = Trip.with_no_transportation_agency
-    # Fallback just in case an edge case is missed
-    else
-      @trips = Trip.with(current_user.staff_agency.id)
-    end
+    # Get trips for the current user's agency and role
+    @trips = current_user.get_trips_for_staff_user
+
+    # Filter trips based on inputs
     @trips = @trips.from_date(@trip_time_from_date).to_date(@trip_time_to_date)
     @trips = @trips.with_purpose(@purposes) unless @purposes.empty?
     @trips = @trips.origin_in(@trip_origin_region.geom) unless @trip_origin_region.empty?

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -107,10 +107,11 @@ class Admin::ReportsController < Admin::AdminController
       @trips = Trip.with_transportation_agency(tas)
     elsif current_user.currently_transportation?
       @trips = Trip.with_transportation_agency(current_user.current_agency.id)
+    elsif current_user.current_agency.nil?
+      @trips = Trip.with_no_transportation_agency
     # Fallback just in case an edge case is missed
     else
-      puts "Got to trips report fallback, returning no trips for #{current_user.email}"
-      @trips = Trip.none
+      @trips = Trip.with(current_user.staff_agency.id)
     end
     @trips = @trips.from_date(@trip_time_from_date).to_date(@trip_time_to_date)
     @trips = @trips.with_purpose(@purposes) unless @purposes.empty?

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -77,10 +77,14 @@ class Admin::ReportsController < Admin::AdminController
       @users = User.all
     elsif current_user.transportation_admin? ||current_user.transportation_staff?
       @users = current_user.travelers_for_staff_agency
-    elsif (current_user.oversight_admin? ||current_user.oversight_staff?) && current_user.currently_oversight?
+    elsif current_user.currently_oversight?
       @users = current_user.travelers_for_oversight_agency
-    elsif (current_user.oversight_admin? ||current_user.oversight_staff?) && current_user.currently_transportation?
+    elsif current_user.currently_transportation?
       @users = current_user.travelers_for_current_agency
+      # Fallback just in case an edge case is missed
+    else
+      puts "Got to users report fallback, returning no users for #{current_user.email}"
+      @users = User.none
     end
     @users = @users.registered unless @include_guests
     @users = @users.with_accommodations(@accommodations) unless @accommodations.empty?
@@ -98,11 +102,15 @@ class Admin::ReportsController < Admin::AdminController
       @trips = Trip.all
     elsif current_user.transportation_admin? ||current_user.transportation_staff?
       @trips = Trip.with_transportation_agency(current_user.staff_agency.id)
-    elsif (current_user.oversight_admin? ||current_user.oversight_staff?) && current_user.currently_oversight?
+    elsif current_user.currently_oversight?
       tas = AgencyOversightAgency.where(oversight_agency_id: current_user.staff_agency.id).pluck(:transportation_agency_id)
       @trips = Trip.with_transportation_agency(tas)
-    elsif (current_user.oversight_admin? ||current_user.oversight_staff?) && current_user.currently_transportation?
+    elsif current_user.currently_transportation?
       @trips = Trip.with_transportation_agency(current_user.current_agency.id)
+    # Fallback just in case an edge case is missed
+    else
+      puts "Got to trips report fallback, returning no trips for #{current_user.email}"
+      @trips = Trip.none
     end
     @trips = @trips.from_date(@trip_time_from_date).to_date(@trip_time_to_date)
     @trips = @trips.with_purpose(@purposes) unless @purposes.empty?
@@ -135,11 +143,15 @@ class Admin::ReportsController < Admin::AdminController
       @services = Service.all
     elsif current_user.transportation_admin? ||current_user.transportation_staff?
       @services = Service.where(agency_id: current_user.staff_agency.id)
-    elsif (current_user.oversight_admin? ||current_user.oversight_staff?) && current_user.currently_oversight?
+    elsif current_user.currently_oversight?
       sids = ServiceOversightAgency.where(oversight_agency_id: current_user.staff_agency.id).pluck(service_id)
       @services = Service.where(id: sids)
-    elsif (current_user.oversight_admin? ||current_user.oversight_staff?) && current_user.currently_transportation?
+    elsif current_user.currently_transportation?
       @services = Service.where(agency_id: current_user.current_agency.id)
+      # Fallback just in case an edge case is missed
+    else
+      puts "Got to service report fallback, returning no services for #{current_user.email}"
+      @services = Service.none
     end
     @services = @services.where(type: @service_type) unless @service_type.blank?
     @services = @services.with_accommodations(@accommodations) unless @accommodations.empty?

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -144,7 +144,7 @@ class Admin::ReportsController < Admin::AdminController
     elsif current_user.transportation_admin? ||current_user.transportation_staff?
       @services = Service.where(agency_id: current_user.staff_agency.id)
     elsif current_user.currently_oversight?
-      sids = ServiceOversightAgency.where(oversight_agency_id: current_user.staff_agency.id).pluck(service_id)
+      sids = ServiceOversightAgency.where(oversight_agency_id: current_user.staff_agency.id).pluck(:service_id)
       @services = Service.where(id: sids)
     elsif current_user.currently_transportation?
       @services = Service.where(agency_id: current_user.current_agency.id)

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -80,9 +80,7 @@ class Admin::ReportsController < Admin::AdminController
       @users = User.all
     elsif current_user.transportation_admin? ||current_user.transportation_staff?
       @users = User.querify(current_user.any_users_for_staff_agency + current_user.travelers_for_staff_agency)
-    elsif current_user.currently_oversight?
-      @users = User.querify(current_user.any_users_for_staff_agency + current_user.travelers_for_oversight_agency)
-    elsif current_user.currently_transportation?
+    elsif current_user.currently_oversight? || current_user.currently_transportation?
       @users = User.querify(current_user.any_users_for_current_agency + current_user.travelers_for_current_agency)
       # Fallback just in case an edge case is missed
     else

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -135,7 +135,7 @@ class Admin::ServicesController < Admin::AdminController
     # If either are empty, or if the Service is a Taxi service, return false
     is_empty = oversight_id&.empty? || transportation_id&.empty?  && !Service::TAXI_SERVICES.include?(@service.type)
     if is_empty
-      flash[:danger] = "Bad combination of Oversight Agency and Transportation Agency for #{@service.name}, did not perform create/ update"
+      flash[:danger] = "Bad combination of Oversight Agency and Transportation Agency for #{@service.name}, did not associate service to selected Oversight Agency"
       return is_empty
     end
 

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -11,11 +11,10 @@ class Admin::ServicesController < Admin::AdminController
     # NOTE: Includes unaffiliated Services by default
     if current_user.superuser?
       @services
-    elsif current_user.currently_oversight? && current_user.oversight_admin?
+    elsif current_user.currently_oversight?
       oa = current_user.staff_agency
-      tas = oa.agency_oversight_agency.pluck(:transportation_agency_id)
-      @services = Service.where(agency_id: [nil,*tas])
-    elsif current_user.currently_transportation? && current_user.oversight_admin?
+      @services = Service.no_agencies_assigned + Service.with_oversight_agency(oa)
+    elsif current_user.currently_transportation?
       @services = Service.where(agency_id: [nil,current_user.current_agency.id])
       # otherwise the current user is probably transportation staff
     else

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -13,6 +13,7 @@ class Admin::ServicesController < Admin::AdminController
                             current_user.accessible_oversight_agencies.order(:name) :
                             Agency.querify([current_user.staff_agency&.agency_oversight_agency&.oversight_agency]).order(:name)
     @transportation_agencies = current_user.accessible_transportation_agencies.order(:name)
+    @default_agency = get_default_tranpsortation_agency_selection
   end
 
   def destroy

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -10,9 +10,9 @@ class Admin::ServicesController < Admin::AdminController
   def index
     @services = get_services_for_current_user
     @oversight_agencies = current_user.accessible_oversight_agencies.length > 0 ?
-                            current_user.accessible_oversight_agencies :
-                            Agency.querify([current_user.staff_agency&.agency_oversight_agency&.oversight_agency])
-    @transportation_agencies = current_user.accessible_transportation_agencies
+                            current_user.accessible_oversight_agencies.order(:name) :
+                            Agency.querify([current_user.staff_agency&.agency_oversight_agency&.oversight_agency]).order(:name)
+    @transportation_agencies = current_user.accessible_transportation_agencies.order(:name)
   end
 
   def destroy

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -33,10 +33,12 @@ class Admin::ServicesController < Admin::AdminController
     oversight_agency_id = os_params[:oversight_agency_id]
     transportation_agency_id = os_params[:transportation_agency_id]
     # Assign the transportation agency based on the passed in id
-    @service.agency = TransportationAgency.find(transportation_agency_id)
+    @service.agency = TransportationAgency.find_by(id:transportation_agency_id)
   	if @service.update_attributes(service_params)
-      if oversight_agency_id != ''
+      if oversight_agency_id != '' && !current_user.superuser?
         ServiceOversightAgency.create(oversight_agency_id: oversight_agency_id, service_id: @service.id)
+      elsif current_user.superuser?
+        ServiceOversightAgency.create(oversight_agency_id: @service.agency&.agency_oversight_agency&.oversight_agency&.id, service_id: @service.id)
       end
       redirect_to admin_service_path(@service)
     else
@@ -53,12 +55,25 @@ class Admin::ServicesController < Admin::AdminController
   def update
     os_params = oversight_params
     @service.update_attributes(service_params)
-    @service.service_oversight_agency.update(oversight_agency_id:os_params[:oversight_agency_id])
+    # If the service doesn't have a service oversight agency and has an agency assigned
+    if @service.service_oversight_agency.nil? && !@service.agency.nil?
+      ServiceOversightAgency.create(oversight_agency_id: @service.agency.agency_oversight_agency.oversight_agency_id, service_id: @service.id)
+    # Else If the service doesn't have a service oversight agency and does not have an agency assigned
+    elsif @service.service_oversight_agency.nil? && @service.agency.nil?
+      ServiceOversightAgency.create(oversight_agency_id: os_params[:oversight_agency_id], service_id: @service.id)
+    # Else If the service has a service oversight agency object, but no oversight agency and no transportation agency
+    elsif @service.service_oversight_agency.oversight_agency.nil? && @service.agency.nil?
+      @service.service_oversight_agency.update(oversight_agency_id: os_params[:oversight_agency_id])
+    # Else update the service's oversight agency with the agency
+    else
+      @service.service_oversight_agency.update(oversight_agency_id:@service.agency&.agency_oversight_agency&.oversight_agency_id)
+    end
     #Force the updated attribute to update, even if only child objects were changeg (e.g., Schedules, Accomodtations, etc.)
     @service.update_attributes({updated_at: Time.now}) 
     present_error_messages(@service)
     # If a partial_path parameter is set, serve back that partial
     respond_with_partial_or do
+      flash[:success] = "#{@service.name} updated successfully."
       redirect_to admin_service_path(@service)
     end    
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -107,7 +107,7 @@ class Admin::UsersController < Admin::AdminController
   end
 
   def change_agency
-    agency = Agency.find(params[:agency_id])
+    agency = Agency.find(params[:agency][:id])
     if !agency.nil?
       current_user.current_agency = agency
       current_user.save!

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -115,11 +115,9 @@ class Admin::UsersController < Admin::AdminController
   end
 
   def change_agency
-    agency = Agency.find(params[:agency][:id])
-    if !agency.nil?
-      current_user.current_agency = agency
-      current_user.save!
-    end
+    agency = Agency.find_by(id:params[:agency][:id])
+    current_user.current_agency = agency
+    current_user.save!
 
     redirect_back(fallback_location: root_path)
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -57,18 +57,17 @@ class Admin::UsersController < Admin::AdminController
     # else if the current user is currently browsing as the oversight admin/ staff
     # - then see all oversight staff/admin AND associated transportation agency staff/admin
     elsif current_user.currently_oversight?
-      oa = current_user.staff_agency
-      @staff = User.any_staff_admin_for_agency(oa)
+      @staff = current_user.any_users_for_staff_agency
     # else if the current user is currently browsing as a transportation agency
     elsif current_user.currently_transportation?
-      @staff = User.any_staff_admin_for_agency(current_user.current_agency)
+      @staff = current_user.any_users_for_current_agency
     # else if the current user decides to view as an unaffiliated user
     elsif current_user.current_agency.nil? && current_user&.staff_agency&.oversight?
       # Return services with no transportation agency and oversight agency
       @staff = User.any_staff_admin_for_none
       # otherwise the current user is probably transportation staff
     else
-      @staff = User.any_staff_admin_for_agency(current_user.staff_agency)
+      @staff = current_user.any_users_for_staff_agency
     end
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -66,8 +66,7 @@ class Admin::UsersController < Admin::AdminController
     # - then see all oversight staff/admin AND associated transportation agency staff/admin
     elsif current_user.currently_oversight?
       oa = current_user.staff_agency
-      tas = TransportationAgency.where(id:oa.agency_oversight_agency.pluck(:transportation_agency_id))
-      @staff = User.any_staff_admin_for_agencies([oa] + tas)
+      @staff = User.any_staff_admin_for_agency(oa)
     # else if the current user is currently browsing as a transportation agency
     elsif current_user.currently_transportation?
       @staff = User.any_staff_admin_for_agency(current_user.current_agency)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -155,6 +155,7 @@ class Admin::UsersController < Admin::AdminController
     end
   end
 
+  # NOTE: Is the below dead code with the new agency restrictions/ role handling??
   # Set admin role on @user if current_user has permissions
   def set_superuser_role(admin_param)
     return false if admin_param.nil?

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -53,6 +53,8 @@ class Admin::UsersController < Admin::AdminController
       @travelers = current_user.travelers_for_staff_agency
     elsif current_user.currently_oversight?
       @travelers = current_user.travelers_for_oversight_agency
+    elsif current_user.current_agency.nil?
+      @travelers = current_user.travelers_for_none
     else
       @travelers = current_user.travelers_for_agency(current_user.current_agency)
     end
@@ -70,7 +72,11 @@ class Admin::UsersController < Admin::AdminController
     # else if the current user is currently browsing as a transportation agency
     elsif current_user.currently_transportation?
       @staff = User.any_staff_admin_for_agency(current_user.current_agency)
-    # otherwise the current user is probably transportation staff
+    # else if the current user decides to view as an unaffiliated user
+    elsif current_user.current_agency.nil? && current_user&.staff_agency&.oversight?
+      # Return services with no transportation agency and oversight agency
+      @staff = User.any_staff_admin_for_none
+      # otherwise the current user is probably transportation staff
     else
       @staff = User.any_staff_admin_for_agency(current_user.staff_agency)
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -47,17 +47,7 @@ class Admin::UsersController < Admin::AdminController
   end
 
   def travelers
-    if current_user.superuser?
-      @travelers = User.travelers
-    elsif current_user.transportation_admin? || current_user.transportation_staff?
-      @travelers = current_user.travelers_for_staff_agency
-    elsif current_user.currently_oversight?
-      @travelers = current_user.travelers_for_oversight_agency
-    elsif current_user.current_agency.nil?
-      @travelers = current_user.travelers_for_none
-    else
-      @travelers = current_user.travelers_for_agency(current_user.current_agency)
-    end
+    @travelers = current_user.get_travelers_for_staff_user
   end
 
   def staff

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -59,15 +59,19 @@ class Admin::UsersController < Admin::AdminController
   end
 
   def staff
+    # If the current user is a superuser
     if current_user.superuser?
       @staff = User.any_role
-    elsif current_user.currently_oversight? && current_user.oversight_admin?
+    # else if the current user is currently browsing as the oversight admin/ staff
+    # - then see all oversight staff/admin AND associated transportation agency staff/admin
+    elsif current_user.currently_oversight?
       oa = current_user.staff_agency
       tas = TransportationAgency.where(id:oa.agency_oversight_agency.pluck(:transportation_agency_id))
-      @staff = User.any_staff_admin_for_agencies(tas)
-    elsif current_user.currently_transportation? && current_user.oversight_admin?
+      @staff = User.any_staff_admin_for_agencies([oa] + tas)
+    # else if the current user is currently browsing as a transportation agency
+    elsif current_user.currently_transportation?
       @staff = User.any_staff_admin_for_agency(current_user.current_agency)
-      # otherwise the current user is probably transportation staff
+    # otherwise the current user is probably transportation staff
     else
       @staff = User.any_staff_admin_for_agency(current_user.staff_agency)
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -118,11 +118,11 @@ class Admin::UsersController < Admin::AdminController
   end
   private
   def set_user_role(role, agency_id)
-    ag = agency_id != '' ? Agency.find_by(id:agency_id) : nil
+    ag = agency_id.present? ? Agency.find_by(id:agency_id) : nil
     User.transaction do
       # If the user can read the selected agency and manage roles
       # then assign the input role and agency to the user
-      if (can? :read, ag) && (can? :manage, Role)
+      if ((can? :read, ag) || ag.nil?) && (can? :manage, Role)
         @user.set_role(role, ag)
       else
         raise ActiveRecord::Rollback

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,7 +1,7 @@
 class Admin::UsersController < Admin::AdminController
 
   # before_action :initialize_user, only: [:index, :create]
-  authorize_resource :except => [:travelers, :staff]
+  authorize_resource
   before_action :load_user
   before_action :load_staff
 
@@ -59,18 +59,18 @@ class Admin::UsersController < Admin::AdminController
   end
 
   def staff
-      if current_user.superuser?
-        @staff = User.any_role
-      elsif current_user.currently_oversight? && current_user.oversight_admin?
-        oa = current_user.staff_agency
-        tas = TransportationAgency.where(id:oa.agency_oversight_agency.pluck(:transportation_agency_id))
-        @staff = User.any_staff_admin_for_agencies(tas)
-      elsif current_user.currently_transportation? && current_user.oversight_admin?
-        @staff = User.any_staff_admin_for_agency(current_user.current_agency)
-        # otherwise the current user is probably transportation staff
-      else
-        @staff = User.any_staff_admin_for_agency(current_user.staff_agency)
-      end
+    if current_user.superuser?
+      @staff = User.any_role
+    elsif current_user.currently_oversight? && current_user.oversight_admin?
+      oa = current_user.staff_agency
+      tas = TransportationAgency.where(id:oa.agency_oversight_agency.pluck(:transportation_agency_id))
+      @staff = User.any_staff_admin_for_agencies(tas)
+    elsif current_user.currently_transportation? && current_user.oversight_admin?
+      @staff = User.any_staff_admin_for_agency(current_user.current_agency)
+      # otherwise the current user is probably transportation staff
+    else
+      @staff = User.any_staff_admin_for_agency(current_user.staff_agency)
+    end
   end
 
   def update

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -88,6 +88,9 @@ class Admin::UsersController < Admin::AdminController
     roles = update_params.delete(:roles)
     staff_agency = update_params.delete(:staff_agency)
     password_confirmation = update_params.delete(:password_confirmation)
+    if roles != '' && staff_agency != ''
+      set_user_role(roles,staff_agency)
+    end
     unless password.blank?
       @user.update_attributes(password: password, password_confirmation: password_confirmation)
     end
@@ -121,12 +124,12 @@ class Admin::UsersController < Admin::AdminController
   end
   private
   def set_user_role(role, agency_id)
-    agency = Agency.find(agency_id)
+    ag = agency_id != '' ? Agency.find_by(id:agency_id) : nil
     User.transaction do
       # If the user can read the selected agency and manage roles
       # then assign the input role and agency to the user
-      if (can? :read, agency) && (can? :manage, Role)
-        @user.set_role(role, agency)
+      if (can? :read, ag) && (can? :manage, Role)
+        @user.set_role(role, ag)
       else
         raise ActiveRecord::Rollback
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < ActionController::Base
       @agency_map = Agency.pluck :name, :id
     elsif current_user.oversight_admin? || current_user.oversight_staff?
       ag_ids = [current_user.staff_agency.id].concat(current_user.staff_agency.agency_oversight_agency.pluck(:transportation_agency_id))
-      @agency_map = Agency.where(id:ag_ids).pluck(:name,:id)
+      @agency_map = Agency.where(id:ag_ids).order(:name).pluck(:name,:id)
     end
     @agency_map.sort!{|a, b| a[0] <=> b[0] }
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -99,7 +99,7 @@ class Ability
       can :manage, Alert
       can :read, :report         # Can view all reports
       # Mapping related permissions
-      can :create, GeographyRecord      # Can create Geography records
+      can :manage, GeographyRecord      # Can create Geography records
       can :manage, Role,                # Can manage roles for current agency
           resource_id: user.staff_agency.id
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -36,7 +36,7 @@ class Ability
         id: user.accessible_staff.pluck(:id).concat(user.travelers_for_staff_agency.pluck(:id))
       can :read, Service,               # Can read services under that user and services with no agency
         id: user.services.pluck(:id).concat(Service.no_agency.pluck(:id))
-      can :manage, Alert                # Can manage alerts
+      can :read, Alert                # Can manage alerts
       can :read, :report         # Can read reports
       can :read, Eligibility
       can :read, Accommodation

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -97,6 +97,7 @@ class Ability
       if user.oversight_admin?                # Can manage Transportation Agencies assigned to the user's Oveersight Agency
         can :manage, Agency,
             id: user.staff_agency.agency_oversight_agency.pluck(:transportation_agency_id)
+        can :create, Agency
         can :manage, Role               # Can manage Roles
         # Mapping related permissions
         can :manage, GeographyRecord    # Can manage geography records

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -69,6 +69,8 @@ class Ability
         can :read, Agency
         can :read, Service,
             id: user.get_services_for_oversight.pluck(:id).concat(Service.no_agencies_assigned.pluck(:id)) # Can access services associated with an oversight agency, and those with no oversight agency
+        can :change_agency, User,
+            id: user.id
       end
       # staff users can update themselves
       can :update, User,

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -31,12 +31,18 @@ class Ability
       ## General Staff Permissions ##
       can [:read, :update], Agency,     # Can read or update their own agency
         id: user.staff_agency.try(:id)
-      can :read, User,                # Can read users that are staff for the same agency and travelers for that agency
+      # NOTE: :staff and :travelers are specified due to how cancan? plugs into Rails Controller actions and authorizes users
+      can [:read,:staff,:travelers], User,                # Can read users that are staff for the same agency and travelers for that agency
         id: user.accessible_staff.pluck(:id).concat(user.travelers_for_staff_agency.pluck(:id))
-      can :read, Service,              # Can read services under that user and services with no agency
+      can :read, Service,               # Can read services under that user and services with no agency
         id: user.services.pluck(:id).concat(Service.no_agency.pluck(:id))
       can :manage, Alert                # Can manage alerts
       can :read, :report         # Can read reports
+      can :read, Eligibility
+      can :read, Accommodation
+      can :read, Purpose
+      can :read, GeographyRecord
+      can :read, Landmark
 
 
       ## TransportationAgency Staff Permissions ##
@@ -59,8 +65,6 @@ class Ability
         can :read, Agency
         can :read, Service,
             id: associated_services.concat(Service.no_agencies_assigned.pluck(:id)) # Can access services associated with an oversight agency, and those with no oversight agency
-        can :read, User
-        can :read, GeographyRecord
       end
       # staff users can update themselves
       can :update, User,
@@ -84,7 +88,7 @@ class Ability
       can [:read, :update], Agency,     # Can read or update their own agency
           id: user.staff_agency.try(:id)
       can :manage, User,                # Can manage users that are staff for the same agency or unaffiliated staff and travelers for that agency
-          id: user.accessible_staff.pluck(:id).concat(User.staff_for_none.pluck(:id),User.admin_for_none.pluck(:id),user.travelers_for_staff_agency.pluck(:id))
+          id: user.accessible_staff.pluck(:id).concat(User.staff_for_none.pluck(:id),User.admin_for_none.pluck(:id),user.get_travelers_for_staff_user.pluck(:id))
       can :manage, Service,             # Can CRUD services with no agency
           id: Service.no_agency.pluck(:id)
       can :create, Service              # Can create new services

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -23,6 +23,7 @@ class Ability
     if user.staff?
       # If a staff user has no agency, then they can only update themselves
       if user.staff_agency.nil?
+        cannot :manage, :all
         can :update, User, id: user.id
         return
       end
@@ -67,11 +68,17 @@ class Ability
     ### ADMIN PERMISSIONS ###
     if user.admin?
       if user.staff_agency.nil?
+        cannot :manage, :all
         can :update, User, id: user.id
         return
       end
 
       # General affiliated admin permissions
+      can :manage, Eligibility
+      can :manage, Accommodation
+      can :manage, Purpose
+      can :manage, Feedback
+      can :manage, Landmark
       can [:read, :update], Agency,     # Can read or update their own agency
           id: user.staff_agency.try(:id)
       can :manage, User,                # Can manage users that are staff for the same agency or unaffiliated staff and travelers for that agency

--- a/app/models/concerns/role_helper.rb
+++ b/app/models/concerns/role_helper.rb
@@ -227,7 +227,7 @@ module RoleHelper
   end
 
   def travelers_for_current_agency
-    ag = Agency.find(self.current_agency.id)
+    ag = Agency.find_by(id:self.current_agency&.id)
     travelers_for_agency(ag)
   end
 

--- a/app/models/concerns/role_helper.rb
+++ b/app/models/concerns/role_helper.rb
@@ -223,13 +223,12 @@ module RoleHelper
   end
 
   def travelers_for_oversight_agency
-    transportation_agencies = AgencyOversightAgency.where(oversight_agency_id: self.staff_agency.id).pluck(:transportation_agency_id)
     travelers_for_agency(self.staff_agency.id)
   end
 
   def travelers_for_current_agency
-    ta = TransportationAgency.find(self.current_agency.id)
-    travelers_for_agency(ta)
+    ag = Agency.find(self.current_agency.id)
+    travelers_for_agency(ag)
   end
 
   ### MODIFYING USER ROLES ###

--- a/app/models/concerns/role_helper.rb
+++ b/app/models/concerns/role_helper.rb
@@ -292,15 +292,15 @@ module RoleHelper
   #
   def get_travelers_for_staff_user
     if self.superuser?
-      @travelers = User.travelers
+      User.travelers
     elsif self.transportation_admin? || self.transportation_staff?
-      @travelers = self.travelers_for_staff_agency
+      self.travelers_for_staff_agency
     elsif self.currently_oversight?
-      @travelers = self.travelers_for_oversight_agency
+      self.travelers_for_oversight_agency
     elsif self.current_agency.nil?
-      @travelers = self.travelers_for_none
+      self.travelers_for_none
     else
-      @travelers = self.travelers_for_agency(self.current_agency)
+      self.travelers_for_agency(self.current_agency)
     end
   end
 

--- a/app/models/concerns/role_helper.rb
+++ b/app/models/concerns/role_helper.rb
@@ -15,6 +15,7 @@ module RoleHelper
     # NOTE: the with_(any_)role method in Rolify <v6.0 is buggy
     # ... and does not work the way it should work
     # see: https://github.com/RolifyCommunity/rolify/issues/362 and the v6.0 release notes
+
     # NOTE: the :any_role scope is probably using Rolify wrong, but seems to work so not touching it
     base.scope :any_role, -> do
       base.querify(base.with_any_role(

--- a/app/models/concerns/role_helper.rb
+++ b/app/models/concerns/role_helper.rb
@@ -200,12 +200,12 @@ module RoleHelper
     # Search for travelers not associated with the input agencies ids
     agency_travelers_id = TravelerTransitAgency.where.not(transportation_agency_id: agencies)
     # Return travelers associated with the input agency and also with no agency
-    User.travelers.where.not(id: agency_travelers_id)
+    User.travelers.where.not(id: agency_travelers_id.pluck(:user_id))
   end
 
   def travelers_for_staff_agency
     if self.staff_agency.oversight?
-      ta = AgencyOversightAgency.where(oversight_agency_id: self.staff_agency.id).select(:transportation_agency_id)
+      ta = AgencyOversightAgency.where(oversight_agency_id: self.staff_agency.id).pluck(:transportation_agency_id)
     else
       ta = TransportationAgency.find(self.staff_agency.id)
     end

--- a/app/models/concerns/role_helper.rb
+++ b/app/models/concerns/role_helper.rb
@@ -173,6 +173,14 @@ module RoleHelper
     Agency.accessible_by(Ability.new(self))
   end
 
+  def accessible_transportation_agencies
+    TransportationAgency.accessible_by(Ability.new(self))
+  end
+
+  def accessible_oversight_agencies
+    OversightAgency.accessible_by(Ability.new(self))
+  end
+
   # Returns a list of users who are staff for any of the agencies this user is staff for
   def fellow_staff
     User.staff_for_any(agencies)

--- a/app/models/concerns/role_helper.rb
+++ b/app/models/concerns/role_helper.rb
@@ -281,6 +281,19 @@ module RoleHelper
   end
 
   ### GENERAL ADMIN CONSOLE BASED HELPERS ###
+  def get_transportation_agencies_for_user
+    if self.superuser?
+      TransportationAgency.all
+    elsif self.currently_oversight? || (self.current_agency.nil? && self.staff_agency.oversight?)
+      Agency.querify([self.accessible_transportation_agencies])
+    elsif self.currently_transportation?
+      Agency.querify([self.current_agency])
+    else
+      Agency.querify([self.staff_agency])
+
+    end
+  end
+
   def get_admin_staff_for_staff_user
     if self.superuser?
       User.staff
@@ -353,7 +366,7 @@ module RoleHelper
                 .where('agency_oversight_agencies.oversight_agency_id': self.staff_agency)
                 .select('agency_oversight_agencies.transportation_agency_id').pluck(:transportation_agency_id)
     Service.left_joins(:service_oversight_agency)
-           .where('service_oversight_agencies.oversight_agency_id = ? OR services.agency_id in (?)', self.current_agency.id, tas)
+           .where('service_oversight_agencies.oversight_agency_id = ? OR services.agency_id in (?)', self.current_agency&.id, tas)
   end
 
 end

--- a/app/models/concerns/role_helper.rb
+++ b/app/models/concerns/role_helper.rb
@@ -189,7 +189,7 @@ module RoleHelper
   end
 
   def currently_oversight?
-    self.current_agency&.oversight?
+    self.current_agency&.oversight? || (self.staff_agency.oversight? && self.current_agency == nil)
   end
 
   def currently_transportation?

--- a/app/models/concerns/role_helper.rb
+++ b/app/models/concerns/role_helper.rb
@@ -186,11 +186,15 @@ module RoleHelper
   end
 
   def currently_oversight?
-    self.current_agency&.oversight? || (self.staff_agency&.oversight? && self.current_agency == nil)
+    self.current_agency&.oversight?
   end
 
   def currently_transportation?
     self.current_agency&.transportation?
+  end
+
+  def travelers_for_none
+    User.travelers.select{|u| u.traveler_transit_agency&.transportation_agency.nil? || u.booking_profiles.length == 0}
   end
 
   def travelers_for_agency(agencies)
@@ -212,7 +216,7 @@ module RoleHelper
 
   def travelers_for_oversight_agency
     transportation_agencies = AgencyOversightAgency.where(oversight_agency_id: self.staff_agency.id).pluck(:transportation_agency_id)
-    travelers_for_agency(transportation_agencies)
+    travelers_for_agency(self.staff_agency.id)
   end
 
   def travelers_for_current_agency

--- a/app/models/concerns/role_helper.rb
+++ b/app/models/concerns/role_helper.rb
@@ -197,7 +197,8 @@ module RoleHelper
     # Search for travelers not associated with the input agencies ids
     agency_travelers_id = TravelerTransitAgency.where.not(transportation_agency_id: agencies)
     # Return travelers associated with the input agency and also with no agency
-    User.travelers.where.not(id: agency_travelers_id.pluck(:user_id))
+    uu = User.travelers.where.not(id: agency_travelers_id.pluck(:user_id))
+    uu.select{|u| u.traveler_transit_agency&.transportation_agency&.present?}
   end
 
   def travelers_for_staff_agency

--- a/app/models/concerns/role_helper.rb
+++ b/app/models/concerns/role_helper.rb
@@ -37,8 +37,8 @@ module RoleHelper
     base.scope :admin_for_any, -> (agencies) { base.with_role_for_instances_or_none(:admin, agencies) }
 
     # SCOPES FOR LOOKING UP BOTH STAFF AND ADMIN
-    base.scope :any_staff_admin_for_agencies, -> (agencies) { base.with_roles_for_instances_or_none([:staff, :admin], agencies) }
-    base.scope :any_staff_admin_for_agency, -> (agency) { base.with_roles_for_instance_or_none([:staff, :admin], agency) }
+    base.scope :any_staff_admin_for_agencies, -> (agencies) { base.with_roles_for_instances([:staff, :admin], agencies) }
+    base.scope :any_staff_admin_for_agency, -> (agency) { base.with_roles_for_instance([:staff, :admin], agency) }
     base.scope :any_staff_admin_for_none, -> { base.with_roles_for_instance_or_none([:staff,:admin],nil) }
 
     # GENERAL USER ROLE SCOPES

--- a/app/models/concerns/role_helper.rb
+++ b/app/models/concerns/role_helper.rb
@@ -241,7 +241,7 @@ module RoleHelper
     end
     if role == "superuser"
       self.add_role(role)
-    elsif agency == ""
+    elsif agency == ""|| agency.nil?
       self.add_role(role)
     elsif staff_agency.nil?
       self.add_role(role,agency)

--- a/app/models/concerns/rolify_addons.rb
+++ b/app/models/concerns/rolify_addons.rb
@@ -31,7 +31,7 @@ module RolifyAddons
 
     scope :with_roles_for_instances_or_none, -> (role_names, instances) do
       joins(:roles).where(roles: {
-        name: role_names.to_s,
+        name: role_names.map{|role| role.to_s},
         resource_id: instances&.pluck(:id).concat([nil])
       })
     end

--- a/app/models/concerns/rolify_addons.rb
+++ b/app/models/concerns/rolify_addons.rb
@@ -15,10 +15,30 @@ module RolifyAddons
       })
     end
 
+    scope :with_roles_for_instance, -> (role_names, instance) do
+      joins(:roles).where(roles: {
+        name: role_names.map{|role| role.to_s},
+        resource_id: instance&.id
+      })
+    end
     scope :with_roles_for_instance_or_none, -> (role_names, instance) do
       joins(:roles).where(roles: {
         name: role_names.map{|role| role.to_s},
         resource_id: [instance&.id].concat([nil])
+      })
+    end
+
+    scope :with_role_for_instances, -> (role_name, instances) do
+      joins(:roles).where(roles: {
+        name: role_name.to_s,
+        resource_id: instances&.pluck(:id)
+      })
+    end
+
+    scope :with_roles_for_instances, -> (role_names, instances) do
+      joins(:roles).where(roles: {
+        name: role_names.map{|role| role.to_s},
+        resource_id: instances&.pluck(:id)
       })
     end
 

--- a/app/models/concerns/rolify_addons.rb
+++ b/app/models/concerns/rolify_addons.rb
@@ -3,7 +3,7 @@
 # https://gist.github.com/jamesmarkcook/0435bb68a3840c89bda4a0e7da81cb24
 module RolifyAddons
   extend ActiveSupport::Concern
-
+  # NOTE: ALL OF THESE SCOPES REQUIRE THE RECORD(S) TO BE PASSED IN AS METHOD PARAMS
   included do
     scope :with_role_for_instance, ->(role_name, instance) do
       resource_name = instance.class.name

--- a/app/models/concerns/rolify_addons.rb
+++ b/app/models/concerns/rolify_addons.rb
@@ -1,0 +1,39 @@
+# Rolify add on based on the linked gist and the parent issue:
+# https://github.com/RolifyCommunity/rolify/issues/362
+# https://gist.github.com/jamesmarkcook/0435bb68a3840c89bda4a0e7da81cb24
+module RolifyAddons
+  extend ActiveSupport::Concern
+
+  included do
+    scope :with_role_for_instance, ->(role_name, instance) do
+      resource_name = instance.class.name
+
+      joins(:roles).where(roles: {
+        name: role_name.to_s,
+        resource_type: resource_name,
+        resource_id: instance&.id
+      })
+    end
+
+    scope :with_roles_for_instance_or_none, -> (role_names, instance) do
+      joins(:roles).where(roles: {
+        name: role_names.map{|role| role.to_s},
+        resource_id: [instance&.id].concat([nil])
+      })
+    end
+
+    scope :with_role_for_instances_or_none, -> (role_name, instances) do
+      joins(:roles).where(roles: {
+        name: role_name.to_s,
+        resource_id: instances&.pluck(:id).concat([nil])
+      })
+    end
+
+    scope :with_roles_for_instances_or_none, -> (role_names, instances) do
+      joins(:roles).where(roles: {
+        name: role_names.to_s,
+        resource_id: instances&.pluck(:id).concat([nil])
+      })
+    end
+  end
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -62,6 +62,25 @@ class Service < ApplicationRecord
   scope :no_agency, -> do
     where(agency_id: nil)
   end
+
+  scope :no_oversight_agency, -> do
+    left_joins(:service_oversight_agency).where('service_oversight_agencies.oversight_agency_id is null')
+  end
+
+  # Find Services with no Oversight Agency and no Transportation Agency
+  scope :no_agencies_assigned, -> do
+    left_joins(:service_oversight_agency).where('service_oversight_agencies.oversight_agency_id is null and services.agency_id is null')
+  end
+
+  scope :with_any_oversight_agency, -> do
+    joins(:service_oversight_agency).where('service_oversight_agencies.oversight_agency_id is not null')
+  end
+
+  # pass in the whole agency record
+  scope :with_oversight_agency, -> (agency) do
+    joins(:service_oversight_agency).where('service_oversight_agencies.oversight_agency_id': agency.id)
+  end
+
   # Filter by age
   scope :by_min_age, -> (age) { where("min_age < ?", age+1) }
   scope :by_max_age, -> (age) { where("max_age > ?", age-1) }

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -89,6 +89,8 @@ class Service < ApplicationRecord
     :schedule, :geography, :eligibility, :accommodation, :purpose
   ]
 
+  TAXI_SERVICES = %w[ Taxi Uber Lyft ]
+
   ### MASTER AVAILABILITY SCOPE ###
   # Returns all services available for the given trip.
   # Optional :only_by and :except_by params allow you to only filter

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -44,7 +44,11 @@ class Trip < ApplicationRecord
 
   ### SCOPES ###
   # Trips where users under an input transportation agency
-  scope :with_transportation_agency, -> (agency_id){where(user_id: TravelerTransitAgency.where(transportation_agency_id: agency_id))}
+  scope :with_transportation_agency, -> (agency_id){where(user_id: TravelerTransitAgency.where(transportation_agency_id: agency_id).pluck(:user_id))}
+  # Trips with no transportation agency
+  scope :with_no_transportation_agency, -> {where.not(user_id: TravelerTransitAgency.where(
+    transportation_agency_id: TransportationAgency.all.pluck(:id)
+  ).pluck(:user_id))}
 
   # Return trips before or after a given date and time
   scope :from_datetime, -> (datetime) { datetime ? where('trip_time >= ?', datetime) : all }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   rolify  # user may be an admin, staff, traveler, ...
   include BookingHelpers::UserHelpers #has_many :booking_profiles, etc.
   include Contactable
+  include RolifyAddons
   include RoleHelper
   include TokenAuthenticationHelpers
   include TravelerProfileUpdater   # Update Profile from API Call

--- a/app/uploaders/shapefile_uploader.rb
+++ b/app/uploaders/shapefile_uploader.rb
@@ -34,7 +34,7 @@ class ShapefileUploader
   end
 
   def update_model_agency(agency)
-    @model.update(agency: agency)
+    @model.update(agency: agency) unless (agency.empty? || agency.nil?)
   end
   private
 

--- a/app/views/admin/accommodations/index.html.haml
+++ b/app/views/admin/accommodations/index.html.haml
@@ -23,8 +23,9 @@
       %td 
         =accommodation.rank
 
-= simple_form_for @new_accommodation, url: admin_accommodations_path, html: {class: 'form-horizontal', multipart: true, method: :post }, authenticity_token: true do |f|
-  =render partial: 'new_accommodation', layout: '/layouts/new_record_panel', locals: {f: f}
+- if can? :create, Accommodation
+  = simple_form_for @new_accommodation, url: admin_accommodations_path, html: {class: 'form-horizontal', multipart: true, method: :post }, authenticity_token: true do |f|
+    =render partial: 'new_accommodation', layout: '/layouts/new_record_panel', locals: {f: f}
 
 :javascript
   $(document).ready(function() {

--- a/app/views/admin/agencies/_edit_agency.html.haml
+++ b/app/views/admin/agencies/_edit_agency.html.haml
@@ -23,7 +23,7 @@
       - if current_user.superuser?
         = foa.input :oversight_agency_id,
           required: true,
-          collection: OversightAgency.all,
+          collection: OversightAgency.all.order(:name),
           label_method: :name,
           value_method: :id,
           selected: @agency.agency_oversight_agency&.oversight_agency_id,

--- a/app/views/admin/agencies/_new_agency.html.haml
+++ b/app/views/admin/agencies/_new_agency.html.haml
@@ -9,7 +9,9 @@
   - if current_user.staff_agency&.oversight?
     = foa.input :oversight_agency_id,
       readonly: true,
-      value: current_user.staff_agency.id,
+      collection: [current_user.staff_agency],
+      label_method: :name,
+      selected: current_user.staff_agency,
       class: 'hidden',
       wrapper_html: {id: 'oversight_select'}
   -# Otherwise, if they're a superuser, render a dropdown

--- a/app/views/admin/agencies/_new_agency.html.haml
+++ b/app/views/admin/agencies/_new_agency.html.haml
@@ -10,6 +10,7 @@
     = foa.input :oversight_agency_id,
       readonly: true,
       collection: [current_user.staff_agency],
+      include_blank: 'Select an Oversight Agency',
       label_method: :name,
       selected: current_user.staff_agency,
       class: 'hidden',
@@ -19,6 +20,7 @@
     = foa.input :oversight_agency_id,
       required: true,
       collection: OversightAgency.all.order(:name),
+      include_blank: 'Select an Oversight Agency',
       label_method: :name,
       value_method: :id,
       wrapper_html: {id: 'oversight_select'}

--- a/app/views/admin/agencies/_new_agency.html.haml
+++ b/app/views/admin/agencies/_new_agency.html.haml
@@ -18,7 +18,7 @@
   - if current_user.superuser?
     = foa.input :oversight_agency_id,
       required: true,
-      collection: OversightAgency.all,
+      collection: OversightAgency.all.order(:name),
       label_method: :name,
       value_method: :id,
       wrapper_html: {id: 'oversight_select'}

--- a/app/views/admin/agencies/show.html.haml
+++ b/app/views/admin/agencies/show.html.haml
@@ -2,7 +2,7 @@
   = "Editing #{@agency.name}"
 
 =render partial: 'edit_agency', layout: '/layouts/panel', locals: {hide_footer: (cannot? :update, @agency)}
-=render partial: 'danger_zone', layout: '/layouts/panel', locals: { panel_style: "danger", hide_delete: (cannot? :delete, @agency) }
+=render partial: 'danger_zone', layout: '/layouts/panel', locals: { panel_style: "danger", hide_delete: (cannot? :delete, @agency), hide_footer:true }
 
 -if can_access_all?(Agency)
   =back_link admin_agencies_path, label: "All Agencies"

--- a/app/views/admin/alerts/index.html.haml
+++ b/app/views/admin/alerts/index.html.haml
@@ -3,8 +3,9 @@
 
 =render partial: "alerts_table"
 
-= simple_form_for @new_alert, url: admin_alerts_path, html: {class: 'form-horizontal', multipart: true, method: :post }, authenticity_token: true do |f|
-  =render partial: 'new_alert', layout: '/layouts/new_record_panel', locals: {f: f}
+- if can? :create, Alert
+  = simple_form_for @new_alert, url: admin_alerts_path, html: {class: 'form-horizontal', multipart: true, method: :post }, authenticity_token: true do |f|
+    =render partial: 'new_alert', layout: '/layouts/new_record_panel', locals: {f: f}
 
 =back_link expired_admin_alerts_path, label: "View Expired Alerts"
 

--- a/app/views/admin/eligibilities/index.html.haml
+++ b/app/views/admin/eligibilities/index.html.haml
@@ -22,9 +22,9 @@
         =eligibility.question
       %td
         =eligibility.rank
-
-= simple_form_for @new_eligibility, url: admin_eligibilities_path, html: {class: 'form-horizontal', multipart: true, method: :post }, authenticity_token: true do |f|
-  =render partial: 'new_eligibility', layout: '/layouts/new_record_panel', locals: {f: f}
+- if can? :create, Eligibility
+  = simple_form_for @new_eligibility, url: admin_eligibilities_path, html: {class: 'form-horizontal', multipart: true, method: :post }, authenticity_token: true do |f|
+    =render partial: 'new_eligibility', layout: '/layouts/new_record_panel', locals: {f: f}
 
 :javascript
   $(document).ready(function() {

--- a/app/views/admin/geographies/_custom_geographies_table.html.haml
+++ b/app/views/admin/geographies/_custom_geographies_table.html.haml
@@ -5,45 +5,9 @@
       -columns.each do |col|
         %th
           =col.to_s.titleize
-      %th
-        Edit
   %tbody
     -records.each do |record|
       %tr
         -columns.each do |col|
           %td
             =record.send(col)
-          %td
-            =simple_form_for record, url: admin_custom_geographies_url do |f|
-              = f.input :id,
-                value: record.id,
-                readonly: true,
-                wrapper_html: {class:'hidden'}
-              -if current_user.superuser?
-                = f.input :agency,
-                  collection: TransportationAgency.all,
-                  selected: record.agency&.id,
-                  wrapper_html: {class:'col-md-6'},
-                  include_blank: "Select an Agency"
-              - if current_user.transportation_admin?
-                = f.input :agency,
-                  collection: [current_user.staff_agency],
-                  selected: record.agency&.id,
-                  readonly: true,
-                  wrapper_html: {class:'col-md-6'},
-                  include_blank: "Select an Agency"
-              -if current_user.currently_oversight?
-                = f.input :agency,
-                  collection: current_user.accessible_agencies,
-                  selected: record.agency&.id,
-                  wrapper_html: {class:'col-md-6'},
-                  include_blank: "Select an Agency"
-              -if current_user.currently_transportation?
-                = f.input :agency,
-                  collection: [current_user.staff_agency],
-                  selected: record.agency&.id,
-                  readonly: true,
-                  wrapper_html: {class:'col-md-6'},
-                  include_blank: "Select an Agency"
-              = f.button :submit, 'Update Geography',
-                class: 'btn btn-primary'

--- a/app/views/admin/geographies/_upload_custom_geographies.html.haml
+++ b/app/views/admin/geographies/_upload_custom_geographies.html.haml
@@ -3,23 +3,9 @@
 
 = f.input "file", required:true, label: "Upload Shapefile", :as => :file
 = simple_form_for :agency do |fa|
-  -if current_user.superuser?
-    = fa.input :agency,
-      collection: TransportationAgency.all,
-      include_blank: "Select an Agency"
-  -if current_user.currently_oversight?
-    = fa.input :agency,
-      collection: current_user.accessible_agencies,
-      include_blank: "Select an Agency"
-  -if current_user&.staff_agency&.transportation?
-    = fa.input :agency,
-      readonly:true,
-      collection: [current_user.staff_agency],
-      selected: current_user.staff_agency.id,
-      include_blank: "Select an Agency"
-  -if current_user.currently_transportation?
-    = fa.input :agency,
-      readonly:true,
-      collection: [current_user.current_agency],
-      selected: current_user.current_agency.id,
-      include_blank: "Select an Agency"
+  = fa.input :agency,
+                collection: @agencies,
+                label: 'Transportation Agency',
+                selected: @agencies&.length == 1 ? @agencies&.first.id : nil,
+                readonly: !current_user.superuser? && !current_user.oversight_admin? && !current_user.transportation_admin?,
+                include_blank: "Select a Transportation Agency"

--- a/app/views/admin/geographies/index.html.haml
+++ b/app/views/admin/geographies/index.html.haml
@@ -2,31 +2,33 @@
   Geography
 
 -# Upload Forms
-.row
-  .col-md-6
-    =simple_form_for :geographies,
-      url: admin_counties_path,
-      html: {class: 'form-horizontal', multipart: true, method: :post },
-      authenticity_token: true do |f|
-      =render partial: 'upload_counties', layout: '/layouts/new_record_panel', locals: {f: f}
-  .col-md-6
-    =simple_form_for :geographies,
-      url: admin_cities_path,
-      html: {class: 'form-horizontal', multipart: true, method: :post },
-      authenticity_token: true do |f|
-      =render partial: 'upload_cities', layout: '/layouts/new_record_panel', locals: {f: f}
-  .col-md-6
-    =simple_form_for :geographies,
-      url: admin_zipcodes_path,
-      html: {class: 'form-horizontal', multipart: true, method: :post },
-      authenticity_token: true do |f|
-      =render partial: 'upload_zipcodes', layout: '/layouts/new_record_panel', locals: {f: f}
-  .col-md-6
-    =simple_form_for :geographies,
-      url: admin_custom_geographies_path,
-      html: {class: 'form-horizontal', multipart: true, method: :post },
-      authenticity_token: true do |f|
-      =render partial: 'upload_custom_geographies', layout: '/layouts/new_record_panel', locals: {f: f}
+-# If the user can create geography records, render the upload forms
+- if can? :create, GeographyRecord
+  .row
+    .col-md-6
+      =simple_form_for :geographies,
+        url: admin_counties_path,
+        html: {class: 'form-horizontal', multipart: true, method: :post },
+        authenticity_token: true do |f|
+        =render partial: 'upload_counties', layout: '/layouts/new_record_panel', locals: {f: f}
+    .col-md-6
+      =simple_form_for :geographies,
+        url: admin_cities_path,
+        html: {class: 'form-horizontal', multipart: true, method: :post },
+        authenticity_token: true do |f|
+        =render partial: 'upload_cities', layout: '/layouts/new_record_panel', locals: {f: f}
+    .col-md-6
+      =simple_form_for :geographies,
+        url: admin_zipcodes_path,
+        html: {class: 'form-horizontal', multipart: true, method: :post },
+        authenticity_token: true do |f|
+        =render partial: 'upload_zipcodes', layout: '/layouts/new_record_panel', locals: {f: f}
+    .col-md-6
+      =simple_form_for :geographies,
+        url: admin_custom_geographies_path,
+        html: {class: 'form-horizontal', multipart: true, method: :post },
+        authenticity_token: true do |f|
+        =render partial: 'upload_custom_geographies', layout: '/layouts/new_record_panel', locals: {f: f}
 
 -# Tables
 .row

--- a/app/views/admin/geographies/index.html.haml
+++ b/app/views/admin/geographies/index.html.haml
@@ -32,21 +32,19 @@
 
 -# Tables
 .row
-  .col-md-12
-    %h2 Custom Geographies
-    =render partial: '/admin/geographies/custom_geographies_table',
-      locals: {columns: [:name], records: @custom_geographies, class: "table-sm"}
-
-.row
-  .col-md-4
+  .col-md-3
     %h2 Counties
     =render partial: '/shared/record_table',
       locals: {columns: [:name, :state], records: @counties, class: "table-sm"}
-  .col-md-4
+  .col-md-3
     %h2 Cities
     =render partial: '/shared/record_table',
       locals: {columns: [:name, :state], records: @cities, class: "table-sm"}
-  .col-md-4
+  .col-md-3
     %h2 Zipcodes
     =render partial: '/shared/record_table',
       locals: {columns: [:name], records: @zipcodes, class: "table-sm"}
+  .col-md-3
+    %h2 Custom
+    =render partial: '/admin/geographies/custom_geographies_table',
+      locals: {columns: [:name], records: @custom_geographies, class: "table-sm"}

--- a/app/views/admin/landmarks/index.html.haml
+++ b/app/views/admin/landmarks/index.html.haml
@@ -32,14 +32,15 @@
       %td
         =landmark.lng
 
-= simple_form_for @landmark,
-    url: admin_landmarks_path,
-    html: {method: :post, class: "form-horizontal" },
-    authenticity_token: true do |f|
-  =render partial: 'new_landmark', layout: '/layouts/new_record_panel', locals: {f: f}
+-if can? :create, Landmark
+  = simple_form_for @landmark,
+      url: admin_landmarks_path,
+      html: {method: :post, class: "form-horizontal" },
+      authenticity_token: true do |f|
+    =render partial: 'new_landmark', layout: '/layouts/new_record_panel', locals: {f: f}
 
-=simple_form_for :landmarks, url: update_all_admin_landmarks_path, html: {class: 'form-horizontal', multipart: true, method: :patch }, authenticity_token: true do |f|
-  =render partial: 'update_landmarks', layout: '/layouts/new_record_panel', locals: {f: f}
+  =simple_form_for :landmarks, url: update_all_admin_landmarks_path, html: {class: 'form-horizontal', multipart: true, method: :patch }, authenticity_token: true do |f|
+    =render partial: 'update_landmarks', layout: '/layouts/new_record_panel', locals: {f: f}
 
 
 :javascript

--- a/app/views/admin/purposes/index.html.haml
+++ b/app/views/admin/purposes/index.html.haml
@@ -20,8 +20,9 @@
       %td
         =purpose.question
 
-= simple_form_for @new_purpose, url: admin_purposes_path, html: {class: 'form-horizontal', multipart: true, method: :post }, authenticity_token: true do |f|
-  =render partial: 'new_purpose', layout: '/layouts/new_record_panel', locals: {f: f}
+- if can? :create, Purpose
+  = simple_form_for @new_purpose, url: admin_purposes_path, html: {class: 'form-horizontal', multipart: true, method: :post }, authenticity_token: true do |f|
+    =render partial: 'new_purpose', layout: '/layouts/new_record_panel', locals: {f: f}
 
 :javascript
   $(document).ready(function() {

--- a/app/views/admin/services/_new_service.html.haml
+++ b/app/views/admin/services/_new_service.html.haml
@@ -9,6 +9,7 @@
     required:true,
     include_blank: 'Select a Transportation Agency for the new Service',
     label_method: :name,
+    selected: @default_agency&.id,
     wrapper_html: {id: 'oversight_select'}
   - default_oversight = current_user.staff_agency&.transportation? ? current_user.staff_agency&.agency_oversight_agency&.oversight_agency&.id : current_user.staff_agency&.id
   = foa.input :oversight_agency_id,

--- a/app/views/admin/services/_new_service.html.haml
+++ b/app/views/admin/services/_new_service.html.haml
@@ -8,12 +8,12 @@
   - if current_user.superuser?
     = foa.input :transportation_agency_id,
       collection: TransportationAgency.all
-    = foa.input :oversight_agency_id,
-      required: true,
-      collection: OversightAgency.all,
-      label_method: :name,
-      value_method: :id,
-      wrapper_html: {id: 'oversight_select'}
+    -# = foa.input :oversight_agency_id,
+    -#   required: true,
+    -#   collection: OversightAgency.all,
+    -#   label_method: :name,
+    -#   value_method: :id,
+    -#   wrapper_html: {id: 'oversight_select'}
   -# if the current user is part of a staff agency, then try set their oversight agency
   - if current_user.staff_agency&.transportation?
     = foa.input :transportation_agency_id,

--- a/app/views/admin/services/_new_service.html.haml
+++ b/app/views/admin/services/_new_service.html.haml
@@ -4,53 +4,19 @@
 = f.input :name, required: true, :as => :string
 = f.input :type, required: true, collection: Service::SERVICE_TYPES, include_blank: "Select a Service Type"
 =simple_form_for :oversight do |foa|
-  -# If they're a superuser, show all transportation and oversight agencies
-  - if current_user.superuser?
-    = foa.input :transportation_agency_id,
-      collection: TransportationAgency.all
-    -# = foa.input :oversight_agency_id,
-    -#   required: true,
-    -#   collection: OversightAgency.all,
-    -#   label_method: :name,
-    -#   value_method: :id,
-    -#   wrapper_html: {id: 'oversight_select'}
-  -# if the current user is part of a staff agency, then try set their oversight agency
-  - if current_user.staff_agency&.transportation?
-    = foa.input :transportation_agency_id,
-        collection: [current_user.staff_agency],
-        readonly:true,
-        include_blank: false,
-        label_method: :name,
-        value_method: :id,
-        selected: current_user.staff_agency.id
-    = foa.input :oversight_agency_id,
-        collection: [current_user.staff_agency.agency_oversight_agency.oversight_agency],
-        readonly:true,
-        include_blank: false,
-        label_method: :name,
-        value_method: :id,
-        selected: current_user.staff_agency.agency_oversight_agency.oversight_agency.id,
-        wrapper_html: {id: 'oversight_select'}
-  -# Automatically assign the new agency to the current user's oversight agency if they are an oversight agency admin
-  - if current_user.staff_agency&.oversight? && current_user.admin?
-    - if current_user.current_agency&.oversight?
-      = foa.input :transportation_agency_id,
-        collection: TransportationAgency.where(id:current_user.current_agency.agency_oversight_agency.pluck(:transportation_agency_id)),
-        label_method: :name,
-        value_method: :id
-    - if current_user.current_agency&.transportation?
-      = foa.input :transportation_agency_id,
-        collection: [current_user.current_agency],
-        readonly:true,
-        include_blank: false,
-        label_method: :name,
-        value_method: :id,
-        selected: current_user.current_agency.id
-    = foa.input :oversight_agency_id,
-        collection: [current_user.staff_agency],
-        readonly:true,
-        include_blank: false,
-        label_method: :name,
-        value_method: :id,
-        selected: current_user.staff_agency.id,
-        wrapper_html: {id: 'oversight_select'}
+  = f.input :agency_id,
+    collection: @transportation_agencies,
+    required:true,
+    include_blank: 'Select a Transportation Agency for the new Service',
+    label_method: :name,
+    wrapper_html: {id: 'oversight_select'}
+  - default_oversight = current_user.staff_agency&.transportation? ? current_user.staff_agency&.agency_oversight_agency&.oversight_agency&.id : current_user.staff_agency&.id
+  = foa.input :oversight_agency_id,
+      collection: @oversight_agencies,
+      readonly: !current_user.superuser? && !current_user.oversight_admin? && !current_user.transportation_admin?,
+      required:true,
+      include_blank: 'Select an Oversight Agency for the new Service',
+      label_method: :name,
+      value_method: :id,
+      selected: default_oversight || '',
+      wrapper_html: {id: 'oversight_select'}

--- a/app/views/admin/services/_service_general_info.html.haml
+++ b/app/views/admin/services/_service_general_info.html.haml
@@ -17,7 +17,7 @@
     required: true,
     include_blank: 'Select a Transportation Agency for the Service',
     selected: @service.agency&.id ,
-    collection: current_user.accessible_transportation_agencies,
+    collection: current_user.accessible_transportation_agencies.order(:name),
     readonly: (@service && (cannot? :update, @service)) ||(@service.nil? && (can? :create, Service))
   =simple_form_for :oversight do |foa|
     = foa.input :oversight_agency_id,

--- a/app/views/admin/services/_service_general_info.html.haml
+++ b/app/views/admin/services/_service_general_info.html.haml
@@ -16,9 +16,9 @@
     =f.association :agency,
       label: 'Transportation Agency',
       include_blank: "Select a Transit Agency",
-      selected: @service.agency&.id,
+      selected: @service.agency&.id ,
       collection: TransportationAgency.where(id:current_user.accessible_agencies.pluck(:id)),
-      readonly: (@service && (cannot? :update, @service)) ||(can? :create, Service )
+      readonly: (@service && (cannot? :update, @service)) ||(@service.nil? && (can? :create, Service))
   -if current_user.superuser?
     =f.association :agency,
       label: 'Transportation Agency',
@@ -30,7 +30,7 @@
       label: 'Transportation Agency',
       include_blank: "Select a Transit Agency",
       selected: @service.agency&.id,
-      collection: current_user.staff_agency.agency_oversight_agency.pluck(:transportation_agency_id)
+      collection: TransportationAgency.where(id:current_user.staff_agency.agency_oversight_agency.pluck(:transportation_agency_id))
   - if current_user.currently_transportation? && current_user.oversight_admin?
     =f.association :agency,
       label: 'Transportation Agency',
@@ -39,34 +39,39 @@
       collection: [current_user.current_agency]
   =simple_form_for :oversight do |foa|
     -# If they're a superuser, show all oversight agencies
+      -# Make the oversight agency input readonly if the service already has an oversight agency
     - if current_user.superuser?
       = foa.input :oversight_agency_id,
         required: true,
         collection: OversightAgency.all,
+        readonly: !@service&.service_oversight_agency&.oversight_agency.nil?,
         label_method: :name,
         value_method: :id,
-        selected: @service.service_oversight_agency.oversight_agency.id,
+        selected: @service&.service_oversight_agency&.oversight_agency&.id,
         wrapper_html: {id: 'oversight_select'}
     - if current_user.staff_agency&.transportation?
       = foa.input :oversight_agency_id,
-          collection: [@service.service_oversight_agency.oversight_agency],
-          readonly:true,
+          collection: [@service&.service_oversight_agency&.oversight_agency || current_user.staff_agency.agency_oversight_agency.oversight_agency],
+          readonly: !@service&.service_oversight_agency&.oversight_agency.nil?,
           include_blank: false,
           label_method: :name,
           value_method: :id,
-          selected: @service.service_oversight_agency.oversight_agency.id,
+          selected: @service&.service_oversight_agency&.oversight_agency&.id,
           wrapper_html: {id: 'oversight_select'}
     - if current_user.currently_oversight? && current_user.oversight_admin?
       = foa.input :oversight_agency_id,
-          collection: [@service.service_oversight_agency.oversight_agency],
-          readonly:true,
+          collection: [@service&.service_oversight_agency&.oversight_agency || current_user.staff_agency],
+          readonly: !@service&.service_oversight_agency&.oversight_agency.nil?,
           include_blank: false,
           label_method: :name,
           value_method: :id,
-          selected: @service.service_oversight_agency.oversight_agency.id,
+          selected: @service&.service_oversight_agency&.oversight_agency&.id || current_user.staff_agency.id,
           wrapper_html: {id: 'oversight_select'}
 
 :javascript
   $(document).ready(function() {
-    new FormHandler($('#{form_selector_from_id}'));
+    const fh =new FormHandler($('#{form_selector_from_id}'));
+    if ('#{@service&.service_oversight_agency&.oversight_agency.nil?}' == 'true') {
+      fh.enableButtons()
+    }
   });

--- a/app/views/admin/services/_service_general_info.html.haml
+++ b/app/views/admin/services/_service_general_info.html.haml
@@ -12,61 +12,24 @@
   =f.input :url
   =f.input :phone
   =f.input :email
-  - if current_user.transportation_staff? || current_user.transportation_admin?
-    =f.association :agency,
-      label: 'Transportation Agency',
-      include_blank: "Select a Transit Agency",
-      selected: @service.agency&.id ,
-      collection: TransportationAgency.where(id:current_user.accessible_agencies.pluck(:id)),
-      readonly: (@service && (cannot? :update, @service)) ||(@service.nil? && (can? :create, Service))
-  -if current_user.superuser?
-    =f.association :agency,
-      label: 'Transportation Agency',
-      include_blank: "Select a Transit Agency",
-      selected: @service.agency&.id,
-      collection: TransportationAgency.all
-  - if current_user.currently_oversight? && current_user.oversight_admin?
-    =f.association :agency,
-      label: 'Transportation Agency',
-      include_blank: "Select a Transit Agency",
-      selected: @service.agency&.id,
-      collection: TransportationAgency.where(id:current_user.staff_agency.agency_oversight_agency.pluck(:transportation_agency_id))
-  - if current_user.currently_transportation? && current_user.oversight_admin?
-    =f.association :agency,
-      label: 'Transportation Agency',
-      include_blank: "Select a Transit Agency",
-      selected: @service.agency&.id,
-      collection: [current_user.current_agency]
+  =f.association :agency,
+    label: 'Transportation Agency',
+    required: true,
+    include_blank: 'Select a Transportation Agency for the Service',
+    selected: @service.agency&.id ,
+    collection: current_user.accessible_transportation_agencies,
+    readonly: (@service && (cannot? :update, @service)) ||(@service.nil? && (can? :create, Service))
   =simple_form_for :oversight do |foa|
-    -# If they're a superuser, show all oversight agencies
-      -# Make the oversight agency input readonly if the service already has an oversight agency
-    - if current_user.superuser?
-      = foa.input :oversight_agency_id,
+    = foa.input :oversight_agency_id,
+        as: :select,
+        collection: current_user.accessible_oversight_agencies.order(:name),
         required: true,
-        collection: OversightAgency.all,
-        readonly: !@service&.service_oversight_agency&.oversight_agency.nil?,
+        readonly: !current_user.superuser? && !current_user.oversight_admin? && !current_user.transportation_admin?,
+        include_blank: 'Select an Oversight Agency for the Service',
         label_method: :name,
         value_method: :id,
         selected: @service&.service_oversight_agency&.oversight_agency&.id,
         wrapper_html: {id: 'oversight_select'}
-    - if current_user.staff_agency&.transportation?
-      = foa.input :oversight_agency_id,
-          collection: [@service&.service_oversight_agency&.oversight_agency || current_user.staff_agency.agency_oversight_agency.oversight_agency],
-          readonly: !@service&.service_oversight_agency&.oversight_agency.nil?,
-          include_blank: false,
-          label_method: :name,
-          value_method: :id,
-          selected: @service&.service_oversight_agency&.oversight_agency&.id,
-          wrapper_html: {id: 'oversight_select'}
-    - if current_user.currently_oversight? && current_user.oversight_admin?
-      = foa.input :oversight_agency_id,
-          collection: [@service&.service_oversight_agency&.oversight_agency || current_user.staff_agency],
-          readonly: !@service&.service_oversight_agency&.oversight_agency.nil?,
-          include_blank: false,
-          label_method: :name,
-          value_method: :id,
-          selected: @service&.service_oversight_agency&.oversight_agency&.id || current_user.staff_agency.id,
-          wrapper_html: {id: 'oversight_select'}
 
 :javascript
   $(document).ready(function() {

--- a/app/views/admin/services/show.html.haml
+++ b/app/views/admin/services/show.html.haml
@@ -29,6 +29,6 @@
   =render partial: 'taxi_accommodations', layout: '/layouts/panel', locals: {hide_footer: (cannot? :update, @service)}
   =render partial: 'lyft_service_area', layout: '/layouts/panel', locals: {hide_footer: (cannot? :update, @service)}
   
-=render partial: 'danger_zone', layout: '/layouts/panel', locals: { panel_style: "danger", hide_delete: (cannot? :delete, @service) }
+=render partial: 'danger_zone', layout: '/layouts/panel', locals: { panel_style: "danger", hide_delete: (cannot? :delete, @service), hide_footer: true }
 
 =back_link admin_services_path, label: "All Services"

--- a/app/views/admin/users/_user_form.html.haml
+++ b/app/views/admin/users/_user_form.html.haml
@@ -13,6 +13,7 @@
   = f.input :roles,
     label: "User Role",
     required: true,
+    prompt: '',
     selected: @user.roles.last.try(:name) || :staff,
     collection: RoleHelper::PERMISSIBLE_CREATES[current_user.roles_name.last.to_sym],
     readonly: @user.valid? && (@user == current_user || (cannot? :update, @user))

--- a/app/views/admin/users/_user_form.html.haml
+++ b/app/views/admin/users/_user_form.html.haml
@@ -12,7 +12,7 @@
   %h4.text-center Roles
   = f.input :roles,
     label: "User Role",
-    selected: @user.roles.last.try(:name),
+    selected: @user.roles.last.try(:name) || :staff,
     collection: RoleHelper::PERMISSIBLE_CREATES[current_user.roles_name.last.to_sym],
     readonly: @user.valid? && (@user == current_user || (cannot? :update, @user))
   - if current_user.superuser? || (current_user.currently_oversight? && current_user.oversight_admin?)
@@ -21,7 +21,8 @@
         collection: current_user.accessible_agencies,
         label: "Staff for: ",
         selected: @user.staff_agency.try(:id),
-        include_blank: "Select an Agency"
+        include_blank: "Select an Agency",
+        readonly: @user.id == current_user.id
   - if current_user.transportation_admin?
     = f.input :staff_agency,
         as: :select,

--- a/app/views/admin/users/_user_form.html.haml
+++ b/app/views/admin/users/_user_form.html.haml
@@ -17,7 +17,7 @@
     readonly: @user.valid? && (@user == current_user || (cannot? :update, @user))
   = f.input :staff_agency,
       as: :select,
-      collection: current_user.accessible_agencies,
+      collection: current_user.accessible_agencies.order(:name),
       label: "Staff for: ",
       selected: @user.staff_agency&.id || @user.current_agency&.id,
       include_blank: "Select an Agency",

--- a/app/views/admin/users/_user_form.html.haml
+++ b/app/views/admin/users/_user_form.html.haml
@@ -12,6 +12,7 @@
   %h4.text-center Roles
   = f.input :roles,
     label: "User Role",
+    required: true,
     selected: @user.roles.last.try(:name) || :staff,
     collection: RoleHelper::PERMISSIBLE_CREATES[current_user.roles_name.last.to_sym],
     readonly: @user.valid? && (@user == current_user || (cannot? :update, @user))

--- a/app/views/admin/users/_user_form.html.haml
+++ b/app/views/admin/users/_user_form.html.haml
@@ -15,25 +15,10 @@
     selected: @user.roles.last.try(:name) || :staff,
     collection: RoleHelper::PERMISSIBLE_CREATES[current_user.roles_name.last.to_sym],
     readonly: @user.valid? && (@user == current_user || (cannot? :update, @user))
-  - if current_user.superuser? || (current_user.currently_oversight? && current_user.oversight_admin?)
-    = f.input :staff_agency,
-        as: :select,
-        collection: current_user.accessible_agencies,
-        label: "Staff for: ",
-        selected: @user.staff_agency.try(:id),
-        include_blank: "Select an Agency",
-        readonly: @user.id == current_user.id
-  - if current_user.transportation_admin?
-    = f.input :staff_agency,
-        as: :select,
-        collection: current_user.accessible_agencies,
-        selected: @user.staff_agency.try(:id),
-        readonly: true,
-        include_blank: false
-  - if current_user.oversight_admin? && current_user.currently_transportation?
-    = f.input :staff_agency,
-        as: :select,
-        collection: [current_user.current_agency],
-        selected: @user.current_agency.try(:id),
-        readonly: true,
-        include_blank: false
+  = f.input :staff_agency,
+      as: :select,
+      collection: current_user.accessible_agencies,
+      label: "Staff for: ",
+      selected: @user.staff_agency&.id || @user.current_agency&.id,
+      include_blank: "Select an Agency",
+      readonly: @user.id == current_user.id

--- a/app/views/admin/users/_user_form.html.haml
+++ b/app/views/admin/users/_user_form.html.haml
@@ -20,6 +20,7 @@
         as: :select,
         collection: current_user.accessible_agencies,
         label: "Staff for: ",
+        selected: @user.staff_agency.try(:id),
         include_blank: "Select an Agency"
   - if current_user.transportation_admin?
     = f.input :staff_agency,

--- a/app/views/admin/users/edit.html.haml
+++ b/app/views/admin/users/edit.html.haml
@@ -7,7 +7,7 @@
 -if @user != current_user && can?(:manage, Role)
   =render partial: 'danger_zone', layout: '/layouts/panel', locals: { panel_style: "danger", hide_footer: true }
 
-- if @user.admin_or_staff?
+- if @user.admin_or_staff? && can?(:read, User)
   =back_link staff_admin_users_path, label: "All Staff"
-- else
+- elsif can?(:read,User)
   =back_link travelers_admin_users_path, label: "All Travelers"

--- a/app/views/admin/users/staff.html.haml
+++ b/app/views/admin/users/staff.html.haml
@@ -27,11 +27,13 @@
         -unless member.last_sign_in_at.nil?
           =member.last_sign_in_at.to_formatted_s(:long)
 
-= simple_form_for @user,
-    url: admin_users_path,
-    html: {method: :post, class: "form-horizontal" },
-    authenticity_token: true do |f|
-  =render partial: 'new_user', layout: '/layouts/new_record_panel', locals: {f: f}
+-# If the current user can manage user roles and create users, then render create new user form
+- if can?(:create, User) && can?(:manage, Role)
+  = simple_form_for @user,
+      url: admin_users_path,
+      html: {method: :post, class: "form-horizontal" },
+      authenticity_token: true do |f|
+    =render partial: 'new_user', layout: '/layouts/new_record_panel', locals: {f: f}
 
 :javascript
   $(document).ready(function() {

--- a/app/views/admin/users/travelers.html.haml
+++ b/app/views/admin/users/travelers.html.haml
@@ -6,6 +6,7 @@
       %th Last Name
       %th First Name
       %th Email
+      %th Agency
       %th Last Signed In
 
   -@travelers.each do |member|
@@ -16,6 +17,8 @@
         =member.first_name
       %td
         =member.email
+      %td
+        =member.traveler_transit_agency&.transportation_agency&.name || "N/A"
       %td
         -unless member.last_sign_in_at.nil?
           =member.last_sign_in_at.to_formatted_s(:long)

--- a/app/views/admin/users/travelers.html.haml
+++ b/app/views/admin/users/travelers.html.haml
@@ -20,12 +20,14 @@
         -unless member.last_sign_in_at.nil?
           =member.last_sign_in_at.to_formatted_s(:long)
 
-= simple_form_for @user,
-    url: admin_users_path,
-    html: {method: :post, class: "form-horizontal" },
-    authenticity_token: true do |f|
-  =hidden_field_tag :is_traveler, true
-  =render partial: 'new_traveler', layout: '/layouts/new_record_panel', locals: {f: f}
+-# If the current user can manage user roles and create users, then render create new user form
+- if can?(:create, User) && can?(:manage, Role)
+  = simple_form_for @user,
+      url: admin_users_path,
+      html: {method: :post, class: "form-horizontal" },
+      authenticity_token: true do |f|
+    =hidden_field_tag :is_traveler, true
+    =render partial: 'new_traveler', layout: '/layouts/new_record_panel', locals: {f: f}
 
 :javascript
   $(document).ready(function() {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
                   <%= form_tag change_agency_admin_users_path do %>
                   <%= select("agency",
                              "id",
-                             options_for_select(@agency_map, selected = (current_user&.current_agency&.id || current_user.staff_agency.id)), {},
+                             options_for_select(@agency_map, selected = (current_user&.current_agency&.id)), {:include_blank => "View As Unaffiliated Staff"},
                              :onchange => "form.submit();") %>
                   <%= hidden_field_tag "come_from", request.fullpath %>
                   <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,7 +32,7 @@
           <ul class="nav navbar-nav navbar-right">
             <% if current_user%>
               <li class="menu-item agency">
-                <% if current_user.oversight_staff? || current_user.oversight_admin? && @agency_map.count > 1 %>
+                <% if current_user.oversight_staff? || current_user.oversight_admin? && @agency_map.count > 0 %>
                   <%= form_tag change_agency_admin_users_path do %>
                   <%= select("agency",
                              "id",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,12 +33,13 @@
             <% if current_user%>
               <li class="menu-item agency">
                 <% if current_user.oversight_staff? || current_user.oversight_admin? && @agency_map.count > 1 %>
-                  <%= form_tag change_agency_admin_users_path %>
-                  <select name="agency_id" onchange="form.submit();">
-                    <%= options_for_select(@agency_map, selected = current_user.current_agency&.id) %>
-                  </select>
+                  <%= form_tag change_agency_admin_users_path do %>
+                  <%= select("agency",
+                             "id",
+                             options_for_select(@agency_map, selected = (current_user&.current_agency&.id || current_user.staff_agency.id)), {},
+                             :onchange => "form.submit();") %>
                   <%= hidden_field_tag "come_from", request.fullpath %>
-                  </form>
+                  <% end %>
                 <% end %>
               </li>
               <li>

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,1 +1,1 @@
-OneclickCore::Application.config.version='v1.17.0-rc.1'
+OneclickCore::Application.config.version='v1.17.0-rc.2'

--- a/lib/tasks/agency_restriction.rake
+++ b/lib/tasks/agency_restriction.rake
@@ -101,7 +101,7 @@ namespace :agency_restriction do
       oa.agency_type = AgencyType.find_by(name:'OversightAgency')
     end
     penn_dot.save
-    puts "Penn DOT Agency created with id: #{penn_dot.id} and agency type of: #{penn_dot.agency_type.name}"
+    puts "Penn DOT Agency created with id: #{penn_dot.id} and agency type of: #{penn_dot.agency_type&.name}"
   end
 
   desc "Assigning all Transportation Agencies to Penn DOT"

--- a/lib/tasks/agency_restriction.rake
+++ b/lib/tasks/agency_restriction.rake
@@ -66,7 +66,9 @@ namespace :agency_restriction do
     puts "Seeding default oversight agency"
     oa = OversightAgency.find_or_create_by(name: "Test Oversight Agency",
                                            email: "test_oversight_agency@oneclick.com",
-                                           published:true)
+                                           published:true) do |oa|
+      oa.agency_type = AgencyType.find_by(name: "OversightAgency")
+    end
     [
       {
         email: "test-oversight-staff@camsys.com",

--- a/lib/tasks/agency_restriction.rake
+++ b/lib/tasks/agency_restriction.rake
@@ -252,7 +252,7 @@ namespace :agency_restriction do
 
   desc "Add agency types"
   task add_agency_type: :environment do
-    %w[PartnerAgency OversightAgency TransportationAgency].each do |type|
+    %w[OversightAgency TransportationAgency].each do |type|
       AgencyType.find_or_create_by(name: type)
     end
   end

--- a/lib/tasks/agency_restriction.rake
+++ b/lib/tasks/agency_restriction.rake
@@ -12,7 +12,7 @@ namespace :agency_restriction do
   task update_default_admin: :environment do
     puts "Updating default admin user to superuser"
     Role.where(name: "superuser").first_or_create
-    default = User.find_by(email: "1-click@faketest.com")
+    default = User.find_by(email: "1-click@camsys.com")
     if default.admin?
       default.add_role("superuser")
       default.remove_role("admin")
@@ -252,9 +252,12 @@ namespace :agency_restriction do
 
   desc "Add agency types"
   task add_agency_type: :environment do
+    final_st = ""
     %w[OversightAgency TransportationAgency].each do |type|
-      AgencyType.find_or_create_by(name: type)
+      ag_t =AgencyType.find_or_create_by(name: type)
+      final_st +="#{ag_t.name}, "
     end
+    puts "Agency types created: #{final_st}"
   end
 
   desc "Associate agencies with agency_type"

--- a/lib/tasks/agency_restriction.rake
+++ b/lib/tasks/agency_restriction.rake
@@ -321,10 +321,10 @@ namespace :agency_restriction do
   task all_qa: [:add_admin, :update_default_admin, :seed_unaffiliated_users,:seed_transportation_users,
         :seed_oversight_agency,:add_agency_type ,:create_and_assign_to_penn_dot,:associate_agency_type,
         :associate_travelers_to_tables,
-        :associate_service_to_penn_dot, :associate_transit_staff,:promote_camsys_to_admin]
+        :associate_service_to_penn_dot, :associate_transit_staff,:assign_camsys_to_admin]
   desc "Do all but update partner agencies for production"
   task all_prod: [:add_admin, :update_default_admin,
         :create_and_assign_to_penn_dot,:associate_travelers_to_county,:associate_agency_type,
         :associate_travelers_to_tables,
-        :associate_transit_staff, :promote_camsys_to_admin]
+        :associate_transit_staff, :assign_camsys_to_admin]
 end

--- a/lib/tasks/agency_restriction.rake
+++ b/lib/tasks/agency_restriction.rake
@@ -318,10 +318,10 @@ namespace :agency_restriction do
   task all_qa: [:add_admin, :update_default_admin, :seed_unaffiliated_users,:seed_transportation_users,
         :seed_oversight_agency,:add_agency_type ,:create_and_assign_to_penn_dot,:associate_agency_type,
         :associate_travelers_to_tables,
-        :associate_service_to_penn_dot, :associate_transit_staff]
+        :associate_service_to_penn_dot, :associate_transit_staff,:promote_camsys_to_admin]
   desc "Do all but update partner agencies for production"
   task all_prod: [:add_admin, :update_default_admin,
         :create_and_assign_to_penn_dot,:associate_travelers_to_county,:associate_agency_type,
         :associate_travelers_to_tables,
-        :associate_transit_staff ]
+        :associate_transit_staff, :promote_camsys_to_admin]
 end

--- a/lib/tasks/agency_restriction.rake
+++ b/lib/tasks/agency_restriction.rake
@@ -12,7 +12,7 @@ namespace :agency_restriction do
   task update_default_admin: :environment do
     puts "Updating default admin user to superuser"
     Role.where(name: "superuser").first_or_create
-    default = User.find_by(email: "1-click@camsys.com")
+    default = User.find_by(email: "1-click@faketest.com")
     if default.admin?
       default.add_role("superuser")
       default.remove_role("admin")
@@ -24,13 +24,13 @@ namespace :agency_restriction do
 
   desc "Seed Unaffiliated Users"
   task seed_unaffiliated_users: :environment do
-    us = User.where(email: 'test-unaffiliated-staff@camsys.com').first_or_create do |user|
+    us = User.where(email: 'test-unaffiliated-staff@faketest.com').first_or_create do |user|
       user.password = 'guest1'
       user.password_confirmation = 'guest1'
       user.add_role(:staff)
       puts 'Creating test unaffiliated staff user'
     end
-    ua = User.where(email: 'test-unaffiliated-admin@camsys.com').first_or_create do |user|
+    ua = User.where(email: 'test-unaffiliated-admin@faketest.com').first_or_create do |user|
       user.password = 'guest1'
       user.password_confirmation = 'guest1'
       user.add_role(:admin)
@@ -43,13 +43,13 @@ namespace :agency_restriction do
   desc "Seed Transportation  Users"
   task seed_transportation_users: :environment do
     ta = TransportationAgency.first
-    us = User.where(email: 'test-transportation-staff@camsys.com').first_or_create do |user|
+    us = User.where(email: 'test-transportation-staff@faketest.com').first_or_create do |user|
       user.password = 'guest1'
       user.password_confirmation = 'guest1'
       ta.add_staff(user)
       puts 'Creating test transportation staff user'
     end
-    ua = User.where(email: 'test-transportation-admin@camsys.com').first_or_create do |user|
+    ua = User.where(email: 'test-transportation-admin@faketest.com').first_or_create do |user|
       user.password = 'guest1'
       user.password_confirmation = 'guest1'
       user.add_role(:admin)
@@ -71,11 +71,11 @@ namespace :agency_restriction do
     end
     [
       {
-        email: "test-oversight-staff@camsys.com",
+        email: "test-oversight-staff@faketest.com",
         password: 'guest1',
         password_confirmation: 'guest1',
       },      {
-        email: "test-oversight-admin@camsys.com",
+        email: "test-oversight-admin@faketest.com",
         password: 'guest1',
         password_confirmation: 'guest1',
       },


### PR DESCRIPTION
Big things changed, fixed, or added since last PR:
- Require both agency and oversight agency in Service create/ update
- Add agency filtering to homepage dashboards, report dashboards, and report downloads
- update traveler sign in so that occ will try associate the traveler to a transit agency if they aren't already
- update geographies page to filter custom geographies by agency
- clean up abilities in app/models/ability.rb
- clean up role helper methods
- include "View as unaffiliated staff" option in agency dropdown
- update how roles are added in agency_restriction rake tasks
- update staff association rake tasks to be more broad in their searches for staff
- fix role_helper queries for staff for agencies due to a bug with Rolify >v6.0.0