### PR TITLE
Pamf-772 Saving Logo bug on General Info Partial

### DIFF
--- a/app/views/admin/services/_service_general_info.html.haml
+++ b/app/views/admin/services/_service_general_info.html.haml
@@ -7,13 +7,11 @@
   General Info
   =render partial: "shared/published_badge", locals: {object: @service}
 
-=simple_form_for @service,
-  url: admin_service_path, remote: true, authenticity_token: true, data: {type: 'html'},
-  html: {class: 'form-horizontal', id: form_id_from_path, multipart: true, method: :put } do |f|
+=simple_form_for @service, url: admin_service_path, remote: true, authenticity_token: true, data: {type: 'html'}, html: {class: 'form-horizontal', id: form_id_from_path, multipart: true, method: :put } do |f|
   =remote_form_input # This sends the partial_path to the controller, so it can serve back the correct partial
 
   =f.input :name, readonly: should_be_readonly
-  =logo_upload_input(f, readonly: should_be_readonly)
+  =logo_upload_input(f, options: {readonly: should_be_readonly, img_src: @service.logo.thumb.url})
   =f.input :url, readonly: should_be_readonly
   =f.input :phone, readonly: should_be_readonly
   =f.input :email, readonly: should_be_readonly
@@ -25,4 +23,9 @@
     if ('#{@service&.service_oversight_agency&.oversight_agency.nil?}' == 'true') {
       fh.enableButtons()
     }
+    const parent = $('#{form_selector_from_id}').closest('.panel').parent();
+    $('#{form_selector_from_id}').bind("ajax:success", function(e, data){
+      let newPanel = $(data);
+      $(parent).prepend($(newPanel[2]).val());
+    });
   });


### PR DESCRIPTION
Issue looked to be the html response was wrapped in a textarea and not rendered, due to the 'remotipart' library.

Fix: 
Javascript to capture the ajax event of successful image upload.
Clean the response html, then drop it back in place.