### PR TITLE
OCC-1183

### DIFF
--- a/app/views/admin/reports/_trips_table_download_options.html.haml
+++ b/app/views/admin/reports/_trips_table_download_options.html.haml
@@ -7,9 +7,7 @@
   as: :string, label: "To Date"
 
 -# FILTER OUT TRIPS NOT CREATED IN ONE CLICK
-=f.input :trip_only_created_in_1click, required: false,
-  as: :boolean,
-  label: 'Only Show Trips Created In 1Click:'
+= f.hidden_field :trip_only_created_in_1click, value: true
   
 -# TRIP PURPOSES
 - unless Config.dashboard_mode == "travel_patterns" && current_user.currently_oversight?


### PR DESCRIPTION
Replaced the checkbox on the admin reports page with a hidden_field to only pull bookings that were created through 1-click. 

Left the functionality to include more reports down the road in case we want to re-introduce pulling in all reports. Might need to comment something like this into the controller to clarify that some code might be redundant for the time being.
